### PR TITLE
Fix for P-256 support due to identity encoding; other improvements

### DIFF
--- a/frost-core/src/frost.rs
+++ b/frost-core/src/frost.rs
@@ -87,9 +87,10 @@ where
     type Error = &'static str;
 
     fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
-        match FromHex::from_hex(hex) {
+        let v: Vec<u8> = FromHex::from_hex(hex).map_err(|_| "invalid hex")?;
+        match v.try_into() {
             Ok(bytes) => Self::from_bytes(bytes).map_err(|_| "malformed scalar encoding"),
-            Err(_) => Err("invalid hex"),
+            Err(_) => Err("malformed scalar encoding"),
         }
     }
 }

--- a/frost-core/src/frost/keys.rs
+++ b/frost-core/src/frost/keys.rs
@@ -95,9 +95,10 @@ where
     type Error = &'static str;
 
     fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
-        match FromHex::from_hex(hex) {
+        let v: Vec<u8> = FromHex::from_hex(hex).map_err(|_| "invalid hex")?;
+        match v.try_into() {
             Ok(bytes) => Self::from_bytes(bytes).map_err(|_| "malformed secret encoding"),
-            Err(_) => Err("invalid hex"),
+            Err(_) => Err("malformed secret encoding"),
         }
     }
 }

--- a/frost-core/src/frost/round1.rs
+++ b/frost-core/src/frost/round1.rs
@@ -62,9 +62,10 @@ where
     type Error = &'static str;
 
     fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
-        match FromHex::from_hex(hex) {
+        let v: Vec<u8> = FromHex::from_hex(hex).map_err(|_| "invalid hex")?;
+        match v.try_into() {
             Ok(bytes) => Self::from_bytes(bytes).map_err(|_| "malformed nonce encoding"),
-            Err(_) => Err("invalid hex"),
+            Err(_) => Err("malformed nonce encoding"),
         }
     }
 }
@@ -124,9 +125,10 @@ where
     type Error = &'static str;
 
     fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
-        match FromHex::from_hex(hex) {
+        let v: Vec<u8> = FromHex::from_hex(hex).map_err(|_| "invalid hex")?;
+        match v.try_into() {
             Ok(bytes) => Self::from_bytes(bytes).map_err(|_| "malformed nonce commitment encoding"),
-            Err(_) => Err("invalid hex"),
+            Err(_) => Err("malformed nonce commitment encoding"),
         }
     }
 }

--- a/frost-core/src/lib.rs
+++ b/frost-core/src/lib.rs
@@ -9,7 +9,6 @@ use std::{
     ops::{Add, Mul, Sub},
 };
 
-use hex::FromHex;
 use rand_core::{CryptoRng, RngCore};
 
 // pub mod batch;
@@ -45,7 +44,7 @@ pub trait Field: Copy + Clone {
     /// A unique byte array buf of fixed length N.
     ///
     /// Little-endian!
-    type Serialization: AsRef<[u8]> + Debug + Default + FromHex + TryFrom<Vec<u8>>;
+    type Serialization: AsRef<[u8]> + Debug + Default + TryFrom<Vec<u8>>;
 
     /// Returns the zero element of the field, the additive identity.
     fn zero() -> Self::Scalar;
@@ -110,7 +109,7 @@ pub trait Group: Copy + Clone {
     /// A unique byte array buf of fixed length N.
     ///
     /// Little-endian!
-    type Serialization: AsRef<[u8]> + Default + FromHex + TryFrom<Vec<u8>>;
+    type Serialization: AsRef<[u8]> + Default + TryFrom<Vec<u8>>;
 
     /// Outputs the order of G (i.e. p)
     ///
@@ -168,7 +167,7 @@ pub trait Ciphersuite: Copy + Clone {
 
     /// A unique byte array of fixed length that is the `Group::ElementSerialization` +
     /// `Group::ScalarSerialization`
-    type SignatureSerialization: AsRef<[u8]> + FromHex + TryFrom<Vec<u8>>;
+    type SignatureSerialization: AsRef<[u8]> + TryFrom<Vec<u8>>;
 
     /// [H1] for a FROST ciphersuite.
     ///

--- a/frost-core/src/lib.rs
+++ b/frost-core/src/lib.rs
@@ -45,7 +45,7 @@ pub trait Field: Copy + Clone {
     /// A unique byte array buf of fixed length N.
     ///
     /// Little-endian!
-    type Serialization: AsRef<[u8]> + AsMut<[u8]> + Debug + Default + FromHex + TryFrom<Vec<u8>>;
+    type Serialization: AsRef<[u8]> + Debug + Default + FromHex + TryFrom<Vec<u8>>;
 
     /// Returns the zero element of the field, the additive identity.
     fn zero() -> Self::Scalar;
@@ -110,7 +110,7 @@ pub trait Group: Copy + Clone {
     /// A unique byte array buf of fixed length N.
     ///
     /// Little-endian!
-    type Serialization: AsRef<[u8]> + AsMut<[u8]> + Default + FromHex + TryFrom<Vec<u8>>;
+    type Serialization: AsRef<[u8]> + Default + FromHex + TryFrom<Vec<u8>>;
 
     /// Outputs the order of G (i.e. p)
     ///

--- a/frost-core/src/lib.rs
+++ b/frost-core/src/lib.rs
@@ -109,7 +109,7 @@ pub trait Group: Copy + Clone {
     /// A unique byte array buf of fixed length N.
     ///
     /// Little-endian!
-    type Serialization: AsRef<[u8]> + Default + TryFrom<Vec<u8>>;
+    type Serialization: AsRef<[u8]> + TryFrom<Vec<u8>>;
 
     /// Outputs the order of G (i.e. p)
     ///

--- a/frost-core/src/signature.rs
+++ b/frost-core/src/signature.rs
@@ -28,7 +28,11 @@ where
         <<C::Group as Group>::Serialization as TryFrom<Vec<u8>>>::Error: Debug,
         <<<C::Group as Group>::Field as Field>::Serialization as TryFrom<Vec<u8>>>::Error: Debug,
     {
-        let mut R_bytes = Vec::from(<C::Group as Group>::Serialization::default().as_ref());
+        // To compute the expected length of the encoded point, encode the generator
+        // and get its length. Note that we can't use the identity because it can be encoded
+        // shorter in some cases (e.g. P-256, which uses SEC1 encoding).
+        let generator = <C::Group as Group>::generator();
+        let mut R_bytes = Vec::from(<C::Group as Group>::serialize(&generator).as_ref());
 
         let R_bytes_len = R_bytes.len();
 

--- a/frost-core/src/verifying_key.rs
+++ b/frost-core/src/verifying_key.rs
@@ -71,9 +71,10 @@ where
     type Error = &'static str;
 
     fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
-        match FromHex::from_hex(hex) {
+        let v: Vec<u8> = FromHex::from_hex(hex).map_err(|_| "invalid hex")?;
+        match v.try_into() {
             Ok(bytes) => Self::from_bytes(bytes).map_err(|_| "malformed verifying key encoding"),
-            Err(_) => Err("invalid hex"),
+            Err(_) => Err("malformed verifying key encoding"),
         }
     }
 }


### PR DESCRIPTION
While doing the P-256 implementation I had to do a small fix and also noticed some possible simplifications (these are all is separate commits so feel free to reject some of them if needed)

- The `AsMut` bound was not needed (and got in the way trying to make `Serialization` with `p256::Encoding`)
- When decoding a signature, it got the serialized length of the first element by serializing the identity. However in P-256 encoding that is a single byte (as an exception) which made the function fail. I changed it to use the generator instead.
- The `FromHex` bound was not strictly needed, since `TryFrom<Vec<u8>>` is available - we can convert from hex to Vec and them use that trait.
- The `Default` bound for `Group` was not being used. I removed it because it will return the identity, which may cause problems in the P-256 case due to its weird encoding. We can leave it though.

