### PR TITLE
Add P-256 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,5 @@ members = [
     "frost-core",
     "frost-redjubjub",
     "frost-ristretto255",
+    "frost-p256",
 ]

--- a/frost-p256/Cargo.toml
+++ b/frost-p256/Cargo.toml
@@ -21,7 +21,6 @@ features = ["nightly"]
 byteorder = "1.4"
 p256 = { version = "0.11.1", features = ["hash2curve"] }
 digest = "0.9"
-elliptic-curve = { version = "0.12.1", default-features = false, features = ["hazmat", "sec1", "hash2curve"] }
 frost-core = { path = "../frost-core" }
 hex = { version = "0.4.3", features = ["serde"] }
 rand_core = "0.6"

--- a/frost-p256/Cargo.toml
+++ b/frost-p256/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "frost-p256"
+edition = "2021"
+# When releasing to crates.io:
+# - Update html_root_url
+# - Update CHANGELOG.md
+# - Create git tag.
+version = "0.1.0"
+authors = ["Deirdre Connolly <durumcrustulum@gmail.com>", "Chelsea Komlo <me@chelseakomlo.com>"]
+readme = "README.md"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/ZcashFoundation/frost"
+categories = ["cryptography"]
+keywords = ["cryptography", "crypto", "threshold", "signature"]
+description = "A Schnorr signature scheme over the NIST P-256 curve that supports FROST ."
+
+[package.metadata.docs.rs]
+features = ["nightly"]
+
+[dependencies]
+byteorder = "1.4"
+p256 = { version = "0.11.1", features = ["hash2curve"] }
+digest = "0.9"
+elliptic-curve = { version = "0.12.1", default-features = false, features = ["hazmat", "sec1", "hash2curve"] }
+frost-core = { path = "../frost-core" }
+hex = { version = "0.4.3", features = ["serde"] }
+rand_core = "0.6"
+serde = { version = "1", optional = true, features = ["derive"] }
+sha2 = "0.10.2"
+thiserror = "1.0"
+zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
+
+[dev-dependencies]
+bincode = "1"
+criterion = "0.3"
+ed25519-dalek = "1.0.1"
+ed25519-zebra = "3.0.0"
+lazy_static = "1.4"
+proptest = "1.0"
+proptest-derive = "0.3"
+rand = "0.8"
+rand_chacha = "0.3"
+serde_json = "1.0"
+
+[features]
+nightly = []
+default = ["serde"]
+
+# [[bench]]
+# name = "bench"
+# harness = false

--- a/frost-p256/README.md
+++ b/frost-p256/README.md
@@ -1,0 +1,32 @@
+An implementation of Schnorr signatures on the P-256 curve for both single and threshold numbers
+of signers (FROST).
+
+## Examples
+
+Creating a `Signature` with a single signer, serializing and deserializing it, and verifying the
+signature:
+
+```rust
+use rand::thread_rng;
+use frost_p256::*;
+
+let msg = b"Hello!";
+
+// Generate a secret key and sign the message
+let sk = SigningKey::new(thread_rng());
+let sig = sk.sign(thread_rng(), msg);
+
+// Types can be converted to raw byte arrays using `from_bytes`/`to_bytes`
+let sig_bytes = sig.to_bytes();
+let pk_bytes = VerifyingKey::from(&sk).to_bytes();
+
+// Deserialize and verify the signature.
+let sig = Signature::from_bytes(sig_bytes)?;
+
+assert!(
+    VerifyingKey::from_bytes(pk_bytes)
+        .and_then(|pk| pk.verify(msg, &sig))
+        .is_ok()
+);
+# Ok::<(), Error>(())
+```

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -38,7 +38,7 @@ impl Field for P256ScalarField {
     }
 
     fn invert(scalar: &Self::Scalar) -> Result<Self::Scalar, Error> {
-        // [`curve25519_dalek::scalar::Scalar`]'s Eq/PartialEq does a constant-time comparison using
+        // [`p256::Scalar`]'s Eq/PartialEq does a constant-time comparison using
         // `ConstantTimeEq`
         if *scalar == <Self as Field>::zero() {
             Err(Error::InvalidZeroScalar)
@@ -88,7 +88,7 @@ impl Group for P256Group {
     /// (1-byte prefix and 32 bytes for the coordinate).
     ///
     /// Note that, in the P-256 spec, the identity is encoded as a single null byte;
-    /// but here we pad with zeroes. This is acceptable as the identity _should_ never 
+    /// but here we pad with zeroes. This is acceptable as the identity _should_ never
     /// be serialized in FROST, else we error.
     ///
     /// [1]: https://secg.org/sec1-v2.pdf

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -187,7 +187,8 @@ impl Ciphersuite for P256Sha256 {
     }
 }
 
-type R = P256Sha256;
+// Shorthand alias for the ciphersuite
+type P = P256Sha256;
 
 ///
 pub mod keys {
@@ -203,23 +204,23 @@ pub mod keys {
     }
 
     ///
-    pub type SharePackage = frost::keys::SharePackage<R>;
+    pub type SharePackage = frost::keys::SharePackage<P>;
 
     ///
-    pub type KeyPackage = frost::keys::KeyPackage<R>;
+    pub type KeyPackage = frost::keys::KeyPackage<P>;
 
     ///
-    pub type PublicKeyPackage = frost::keys::PublicKeyPackage<R>;
+    pub type PublicKeyPackage = frost::keys::PublicKeyPackage<P>;
 }
 
 ///
 pub mod round1 {
     use super::*;
     ///
-    pub type SigningNonces = frost::round1::SigningNonces<R>;
+    pub type SigningNonces = frost::round1::SigningNonces<P>;
 
     ///
-    pub type SigningCommitments = frost::round1::SigningCommitments<R>;
+    pub type SigningCommitments = frost::round1::SigningCommitments<P>;
 
     ///
     pub fn preprocess<RNG>(
@@ -230,22 +231,22 @@ pub mod round1 {
     where
         RNG: CryptoRng + RngCore,
     {
-        frost::round1::preprocess::<R, RNG>(num_nonces, participant_index, rng)
+        frost::round1::preprocess::<P, RNG>(num_nonces, participant_index, rng)
     }
 }
 
 ///
-pub type SigningPackage = frost::SigningPackage<R>;
+pub type SigningPackage = frost::SigningPackage<P>;
 
 ///
 pub mod round2 {
     use super::*;
 
     ///
-    pub type SignatureShare = frost::round2::SignatureShare<R>;
+    pub type SignatureShare = frost::round2::SignatureShare<P>;
 
     ///
-    pub type SigningPackage = frost::SigningPackage<R>;
+    pub type SigningPackage = frost::SigningPackage<P>;
 
     ///
     pub fn sign(
@@ -258,7 +259,7 @@ pub mod round2 {
 }
 
 ///
-pub type Signature = frost_core::Signature<R>;
+pub type Signature = frost_core::Signature<P>;
 
 ///
 pub fn aggregate(
@@ -270,7 +271,7 @@ pub fn aggregate(
 }
 
 ///
-pub type SigningKey = frost_core::SigningKey<R>;
+pub type SigningKey = frost_core::SigningKey<P>;
 
 ///
-pub type VerifyingKey = frost_core::VerifyingKey<R>;
+pub type VerifyingKey = frost_core::VerifyingKey<P>;

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
 
-use elliptic_curve::hash2curve::{hash_to_field, ExpandMsgXmd};
+use p256::elliptic_curve::hash2curve::{hash_to_field, ExpandMsgXmd};
 use p256::{
     elliptic_curve::{
         sec1::{FromEncodedPoint, ToEncodedPoint},

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -3,7 +3,6 @@
 #![doc = include_str!("../README.md")]
 
 use elliptic_curve::hash2curve::{hash_to_field, ExpandMsgXmd};
-use hex::FromHex;
 use p256::{
     elliptic_curve::{
         sec1::{FromEncodedPoint, ToEncodedPoint},
@@ -22,7 +21,7 @@ mod tests;
 pub use frost_core::Error;
 
 #[derive(Clone, Copy)]
-/// An implementation of the FROST ciphersuite scalar field.
+/// An implementation of the FROST P-256 SHA-256 ciphersuite scalar field.
 pub struct P256ScalarField;
 
 impl Field for P256ScalarField {
@@ -77,7 +76,7 @@ impl Field for P256ScalarField {
 }
 
 #[derive(Clone, Copy, PartialEq)]
-/// An implementation of the FROST ciphersuite group.
+/// An implementation of the FROST P-256 ciphersuite group.
 pub struct P256Group;
 
 impl Group for P256Group {
@@ -87,8 +86,10 @@ impl Group for P256Group {
 
     /// [SEC 1][1] serialization of a compressed point in P-256 takes 33 bytes
     /// (1-byte prefix and 32 bytes for the coordinate).
-    /// Note that, in the spec, the identity is encoded as a single null byte;
-    /// bute here we pad with zeroes.
+    ///
+    /// Note that, in the P-256 spec, the identity is encoded as a single null byte;
+    /// but here we pad with zeroes. This is acceptable as the identity _should_ never 
+    /// be serialized in FROST, else we error.
     ///
     /// [1]: https://secg.org/sec1-v2.pdf
     type Serialization = [u8; 33];

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -1,0 +1,300 @@
+#![allow(non_snake_case)]
+#![deny(missing_docs)]
+#![doc = include_str!("../README.md")]
+
+use elliptic_curve::hash2curve::{hash_to_field, ExpandMsgXmd};
+use hex::FromHex;
+use p256::{
+    elliptic_curve::{
+        sec1::{FromEncodedPoint, ToEncodedPoint},
+        Field as FFField, PrimeField,
+    },
+    AffinePoint, ProjectivePoint, Scalar,
+};
+use rand_core::{CryptoRng, RngCore};
+use sha2::{digest::Update, Digest, Sha256};
+
+use frost_core::{frost, Ciphersuite, Field, Group};
+
+#[cfg(test)]
+mod tests;
+
+pub use frost_core::Error;
+
+#[derive(Clone, Copy)]
+/// An implementation of the FROST ciphersuite scalar field.
+pub struct P256ScalarField;
+
+impl Field for P256ScalarField {
+    type Scalar = Scalar;
+
+    type Serialization = [u8; 32];
+
+    fn zero() -> Self::Scalar {
+        Scalar::ZERO
+    }
+
+    fn one() -> Self::Scalar {
+        Scalar::ONE
+    }
+
+    fn invert(scalar: &Self::Scalar) -> Result<Self::Scalar, Error> {
+        // [`curve25519_dalek::scalar::Scalar`]'s Eq/PartialEq does a constant-time comparison using
+        // `ConstantTimeEq`
+        if *scalar == <Self as Field>::zero() {
+            Err(Error::InvalidZeroScalar)
+        } else {
+            Ok(scalar.invert().unwrap())
+        }
+    }
+
+    fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
+        Scalar::random(rng)
+    }
+
+    fn random_nonzero<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
+        loop {
+            let scalar = Scalar::random(&mut *rng);
+
+            // This impl of `Eq` calls to `ConstantTimeEq` under the hood
+            if scalar != Scalar::zero() {
+                return scalar;
+            }
+        }
+    }
+
+    fn serialize(scalar: &Self::Scalar) -> Self::Serialization {
+        scalar.to_bytes().into()
+    }
+
+    fn deserialize(buf: &Self::Serialization) -> Result<Self::Scalar, Error> {
+        let field_bytes: &p256::FieldBytes = buf.into();
+        match Scalar::from_repr(*field_bytes).into() {
+            Some(s) => Ok(s),
+            None => Err(Error::MalformedScalar),
+        }
+    }
+}
+
+/// Wrapper for [`p256::EncodedPoint`].
+#[derive(Default)]
+pub struct P256Serialization(p256::EncodedPoint);
+
+impl AsRef<p256::EncodedPoint> for P256Serialization {
+    fn as_ref(&self) -> &p256::EncodedPoint {
+        &self.0
+    }
+}
+
+impl From<p256::EncodedPoint> for P256Serialization {
+    fn from(encoded_point: p256::EncodedPoint) -> Self {
+        Self(encoded_point)
+    }
+}
+
+impl FromHex for P256Serialization {
+    type Error = &'static str;
+
+    fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
+        let data = hex::decode(hex).map_err(|_| "hex decode error")?;
+        Ok(p256::EncodedPoint::from_bytes(data)
+            .map_err(|_| "point decode error")?
+            .into())
+    }
+}
+
+impl AsRef<[u8]> for P256Serialization {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl TryFrom<Vec<u8>> for P256Serialization {
+    type Error = &'static str;
+
+    fn try_from(data: Vec<u8>) -> Result<Self, Self::Error> {
+        Ok(p256::EncodedPoint::from_bytes(data)
+            .map_err(|_| "point decode error")?
+            .into())
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+/// An implementation of the FROST ciphersuite group.
+pub struct P256Group;
+
+impl Group for P256Group {
+    type Field = P256ScalarField;
+
+    type Element = ProjectivePoint;
+
+    type Serialization = P256Serialization;
+
+    fn order() -> <Self::Field as Field>::Scalar {
+        // TODO: rethink this, no way to represent the order in `Scalar`
+        Scalar::zero()
+    }
+
+    fn cofactor() -> <Self::Field as Field>::Scalar {
+        Scalar::one()
+    }
+
+    fn identity() -> Self::Element {
+        ProjectivePoint::IDENTITY
+    }
+
+    fn generator() -> Self::Element {
+        ProjectivePoint::GENERATOR
+    }
+
+    fn serialize(element: &Self::Element) -> Self::Serialization {
+        element.to_affine().to_encoded_point(true).into()
+    }
+
+    fn deserialize(buf: &Self::Serialization) -> Result<Self::Element, Error> {
+        match Option::<AffinePoint>::from(AffinePoint::from_encoded_point(&buf.0)) {
+            Some(point) => Ok(ProjectivePoint::from(point).into()),
+            None => Err(Error::MalformedElement),
+        }
+    }
+}
+
+/// Context string from the ciphersuite in the [spec]
+///
+/// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-04.txt
+
+const CONTEXT_STRING: &str = "FROST-P256-SHA256";
+
+#[derive(Clone, Copy, PartialEq)]
+/// An implementation of the FROST ciphersuite FROST(P-256, SHA-256).
+pub struct P256Sha256;
+
+impl Ciphersuite for P256Sha256 {
+    type Group = P256Group;
+
+    type HashOutput = [u8; 32];
+
+    type SignatureSerialization = [u8; 65];
+
+    /// H1 for FROST(P-256, SHA-256)
+    ///
+    /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-04.html#name-frostp-256-sha-256
+    fn H1(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
+        let mut u = [P256ScalarField::zero()];
+        let dst = CONTEXT_STRING.to_owned() + "rho";
+        hash_to_field::<ExpandMsgXmd<Sha256>, Scalar>(&vec![m], dst.as_bytes(), &mut u).unwrap();
+        u[0]
+    }
+
+    /// H2 for FROST(P-256, SHA-256)
+    ///
+    /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-04.html#name-frostp-256-sha-256
+    fn H2(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
+        let mut u = [P256ScalarField::zero()];
+        let dst = CONTEXT_STRING.to_owned() + "chal";
+        hash_to_field::<ExpandMsgXmd<Sha256>, Scalar>(&vec![m], dst.as_bytes(), &mut u).unwrap();
+        u[0]
+    }
+
+    /// H3 for FROST(P-256, SHA-256)
+    ///
+    /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-04.html#name-frostp-256-sha-256
+    fn H3(m: &[u8]) -> Self::HashOutput {
+        let h = Sha256::new()
+            .chain(CONTEXT_STRING.as_bytes())
+            .chain("digest")
+            .chain(m);
+
+        let mut output = [0u8; 32];
+        output.copy_from_slice(h.finalize().as_slice());
+        output
+    }
+}
+
+type R = P256Sha256;
+
+///
+pub mod keys {
+    use super::*;
+
+    ///
+    pub fn keygen_with_dealer<RNG: RngCore + CryptoRng>(
+        num_signers: u8,
+        threshold: u8,
+        mut rng: RNG,
+    ) -> Result<(Vec<SharePackage>, PublicKeyPackage), &'static str> {
+        frost::keys::keygen_with_dealer(num_signers, threshold, &mut rng)
+    }
+
+    ///
+    pub type SharePackage = frost::keys::SharePackage<R>;
+
+    ///
+    pub type KeyPackage = frost::keys::KeyPackage<R>;
+
+    ///
+    pub type PublicKeyPackage = frost::keys::PublicKeyPackage<R>;
+}
+
+///
+pub mod round1 {
+    use super::*;
+    ///
+    pub type SigningNonces = frost::round1::SigningNonces<R>;
+
+    ///
+    pub type SigningCommitments = frost::round1::SigningCommitments<R>;
+
+    ///
+    pub fn preprocess<RNG>(
+        num_nonces: u8,
+        participant_index: u16,
+        rng: &mut RNG,
+    ) -> (Vec<SigningNonces>, Vec<SigningCommitments>)
+    where
+        RNG: CryptoRng + RngCore,
+    {
+        frost::round1::preprocess::<R, RNG>(num_nonces, participant_index, rng)
+    }
+}
+
+///
+pub type SigningPackage = frost::SigningPackage<R>;
+
+///
+pub mod round2 {
+    use super::*;
+
+    ///
+    pub type SignatureShare = frost::round2::SignatureShare<R>;
+
+    ///
+    pub type SigningPackage = frost::SigningPackage<R>;
+
+    ///
+    pub fn sign(
+        signing_package: &SigningPackage,
+        signer_nonces: &round1::SigningNonces,
+        key_package: &keys::KeyPackage,
+    ) -> Result<SignatureShare, &'static str> {
+        frost::round2::sign(&signing_package, signer_nonces, key_package)
+    }
+}
+
+///
+pub type Signature = frost_core::Signature<R>;
+
+///
+pub fn aggregate(
+    signing_package: &round2::SigningPackage,
+    signature_shares: &[round2::SignatureShare],
+    pubkeys: &keys::PublicKeyPackage,
+) -> Result<Signature, &'static str> {
+    frost::aggregate(&signing_package, &signature_shares[..], &pubkeys)
+}
+
+///
+pub type SigningKey = frost_core::SigningKey<R>;
+
+///
+pub type VerifyingKey = frost_core::VerifyingKey<R>;

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -128,6 +128,7 @@ impl Group for P256Group {
     fn deserialize(buf: &Self::Serialization) -> Result<Self::Element, Error> {
         let encoded_point =
             p256::EncodedPoint::from_bytes(buf).map_err(|_| Error::MalformedElement)?;
+
         match Option::<AffinePoint>::from(AffinePoint::from_encoded_point(&encoded_point)) {
             Some(point) => Ok(ProjectivePoint::from(point)),
             None => Err(Error::MalformedElement),
@@ -138,7 +139,6 @@ impl Group for P256Group {
 /// Context string from the ciphersuite in the [spec]
 ///
 /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-04.txt
-
 const CONTEXT_STRING: &str = "FROST-P256-SHA256";
 
 #[derive(Clone, Copy, PartialEq)]

--- a/frost-p256/src/tests.rs
+++ b/frost-p256/src/tests.rs
@@ -1,0 +1,153 @@
+use rand::thread_rng;
+
+use crate::*;
+
+mod vectors;
+
+use vectors::*;
+
+/// This is testing that Shamir's secret sharing to compute and arbitrary
+/// value is working.
+#[test]
+fn check_share_generation_p256_sha256() {
+    let mut rng = thread_rng();
+
+    let secret = frost::keys::Secret::<P256Sha256>::random(&mut rng);
+
+    let secret_shares = frost::keys::generate_secret_shares(&secret, 5, 3, rng).unwrap();
+
+    for secret_share in secret_shares.iter() {
+        assert_eq!(secret_share.verify(), Ok(()));
+    }
+
+    assert_eq!(
+        frost::keys::reconstruct_secret::<P256Sha256>(secret_shares).unwrap(),
+        secret
+    )
+}
+
+#[test]
+fn check_sign_with_test_vectors() {
+    let (
+        group_public,
+        key_packages,
+        _message,
+        message_bytes,
+        signer_nonces,
+        signer_commitments,
+        group_binding_factor_input,
+        group_binding_factor,
+        signature_shares,
+        signature_bytes,
+    ) = parse_test_vectors();
+
+    type R = P256Sha256;
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Key generation
+    ////////////////////////////////////////////////////////////////////////////
+
+    for key_package in key_packages.values() {
+        assert_eq!(
+            *key_package.public(),
+            frost::keys::Public::from(*key_package.secret_share())
+        );
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Round 1: generating nonces and signing commitments for each participant
+    /////////////////////////////////////////////////////////////////////////////
+
+    for (i, _) in signer_commitments.clone() {
+        // compute nonce commitments from nonces
+        let nonces = signer_nonces.get(&i).unwrap();
+        let nonce_commitments = signer_commitments.get(&i).unwrap();
+
+        assert_eq!(
+            &frost::round1::NonceCommitment::from(nonces.hiding()),
+            nonce_commitments.hiding()
+        );
+
+        assert_eq!(
+            &frost::round1::NonceCommitment::from(nonces.binding()),
+            nonce_commitments.binding()
+        );
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    // Round 2: each participant generates their signature share
+    /////////////////////////////////////////////////////////////////////////////
+
+    let signer_commitments_vec = signer_commitments
+        .into_iter()
+        .map(|(_, signing_commitments)| signing_commitments)
+        .collect();
+
+    let signing_package = frost::SigningPackage::new(signer_commitments_vec, message_bytes);
+
+    assert_eq!(signing_package.rho_preimage(), group_binding_factor_input);
+
+    let rho: frost::Rho<R> = (&signing_package).into();
+
+    assert_eq!(rho, group_binding_factor);
+
+    let mut our_signature_shares: Vec<frost::round2::SignatureShare<R>> = Vec::new();
+
+    // Each participant generates their signature share
+    for index in signer_nonces.keys() {
+        let key_package = &key_packages[index];
+        let nonces = &signer_nonces[index];
+
+        // Each participant generates their signature share.
+        let signature_share = frost::round2::sign(&signing_package, nonces, key_package).unwrap();
+
+        our_signature_shares.push(signature_share);
+    }
+
+    for sig_share in our_signature_shares.clone() {
+        assert_eq!(sig_share, signature_shares[sig_share.index()]);
+    }
+
+    let signer_pubkeys = key_packages
+        .into_iter()
+        .map(|(i, key_package)| (i, *key_package.public()))
+        .collect();
+
+    let pubkey_package = frost::keys::PublicKeyPackage {
+        signer_pubkeys,
+        group_public,
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Aggregation:  collects the signing shares from all participants,
+    // generates the final signature.
+    ////////////////////////////////////////////////////////////////////////////
+
+    // Aggregate the FROST signature from test vector sig shares
+    let group_signature_result = frost::aggregate(
+        &signing_package,
+        &signature_shares
+            .values()
+            .cloned()
+            .collect::<Vec<frost::round2::SignatureShare<R>>>(),
+        &pubkey_package,
+    );
+
+    // Check that the aggregation passed signature share verification and generation
+    assert!(group_signature_result.is_ok());
+
+    // Check that the generated signature matches the test vector signature
+    let group_signature = group_signature_result.unwrap();
+    assert_eq!(group_signature.to_bytes().to_vec(), signature_bytes);
+
+    // Aggregate the FROST signature from our signature shares
+    let group_signature_result =
+        frost::aggregate(&signing_package, &our_signature_shares, &pubkey_package);
+
+    // Check that the aggregation passed signature share verification and generation
+    assert!(group_signature_result.is_ok());
+
+    // Check that the generated signature matches the test vector signature
+    let group_signature = group_signature_result.unwrap();
+    assert_eq!(group_signature.to_bytes().to_vec(), signature_bytes);
+}

--- a/frost-p256/src/tests/vectors.json
+++ b/frost-p256/src/tests/vectors.json
@@ -1,0 +1,59 @@
+{
+  "config": {
+    "MAX_SIGNERS": "3",
+    "NUM_SIGNERS": "2",
+    "THRESHOLD_LIMIT": "2",
+    "name": "FROST(P-256, SHA-256)",
+    "group": "P-256",
+    "hash": "SHA-256"
+  },
+  "inputs": {
+    "group_secret_key": "6f090d1393ff53bbcbba036c00b8830ab4546c251dece199eb03a6a51a5a5929",
+    "group_public_key": "03db0945167b62e6472ad46373b6cbbca88e2a9a4883071f0b3fde4b2b6d7b6ba6",
+    "message": "74657374",
+    "signers": {
+      "1": {
+        "signer_share": "738552e18ea4f2090597aca6c23c1666845c21c676813f9e26786f1e410dcecf"
+      },
+      "2": {
+        "signer_share": "780198af894a90563f7555e183bfa9c25463d767cf159da261ed379767c14475"
+      },
+      "3": {
+        "signer_share": "7c7dde7d83f02ea37952ff1c45433d1e246b8d0927a9fba69d6200108e74ba1b"
+      }
+    }
+  },
+  "round_one_outputs": {
+    "participants": "1,2",
+    "group_binding_factor_input": "000102f34caab210d59324e12ba41f0802d9545f7f702906930766b86c462bb8ff7f3402b724640ea9e262469f401c9006991ba3247c2c91b97cdb1f0eeab1a777e24e1e0002037f8a998dfc2e60a7ad63bc987cb27b8abf78a68bd924ec6adb9f251850cbe711024a4e90422a19dd8463214e997042206c39d3df56168b458592462090c89dbcf84efca0c54f70a585d6aae28679482b4aed03ae5d38297b9092ab3376d46fdf55",
+    "group_binding_factor": "9df349a9f34bf01627f6b4f8b376e8c8261d55508d1cac2919cdaf7f9cb20e70",
+    "signers": {
+      "1": {
+        "hiding_nonce": "3da92a503cf7e3f72f62dabedbb3ffcc9f555f1c1e78527940fe3fed6d45e56f",
+        "binding_nonce": "ec97c41fc77ae7e795067976b2edd8b679f792abb062e4d0c33f0f37d2e363eb",
+        "hiding_nonce_commitment": "02f34caab210d59324e12ba41f0802d9545f7f702906930766b86c462bb8ff7f34",
+        "binding_nonce_commitment": "02b724640ea9e262469f401c9006991ba3247c2c91b97cdb1f0eeab1a777e24e1e"
+      },
+      "2": {
+        "hiding_nonce": "06cb4425031e695d1f8ac61320717d63918d3edc7a02fcd3f23ade47532b1fd9",
+        "binding_nonce": "2d965a4ea73115b8065c98c1d95c7085db247168012a834d8285a7c02f11e3e0",
+        "hiding_nonce_commitment": "037f8a998dfc2e60a7ad63bc987cb27b8abf78a68bd924ec6adb9f251850cbe711",
+        "binding_nonce_commitment": "024a4e90422a19dd8463214e997042206c39d3df56168b458592462090c89dbcf8"
+      }
+    }
+  },
+  "round_two_outputs": {
+    "participants": "1,2",
+    "signers": {
+      "1": {
+        "sig_share": "120a8ef8a5936444d8087cb10df5648629895e94582720760a10c8c217e3417b"
+      },
+      "2": {
+        "sig_share": "2a7ff42d849f1bcc0e5f75d5810900a3e8f68ab717ff10d7a6da89f8bb0c16aa"
+      }
+    }
+  },
+  "final_output": {
+    "sig": "035cfbd148da711bbc823455b682ed01a1be3c5415cf692f4a91b7fe22d1dec3453c8a83262a328010e667f2868efe652a127fe94b7026314db0eb52bad2ef5825"
+  }
+}

--- a/frost-p256/src/tests/vectors.rs
+++ b/frost-p256/src/tests/vectors.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, str::FromStr};
 
-use elliptic_curve::PrimeField;
 use hex::{self, FromHex};
 use lazy_static::lazy_static;
+use p256::elliptic_curve::PrimeField;
 use p256::{FieldBytes, Scalar};
 use serde_json::Value;
 

--- a/frost-p256/src/tests/vectors.rs
+++ b/frost-p256/src/tests/vectors.rs
@@ -1,0 +1,143 @@
+use std::{collections::HashMap, str::FromStr};
+
+use elliptic_curve::PrimeField;
+use hex::{self, FromHex};
+use lazy_static::lazy_static;
+use p256::{FieldBytes, Scalar};
+use serde_json::Value;
+
+use frost_core::{
+    frost::{keys::*, round1::*, round2::*, *},
+    VerifyingKey,
+};
+
+use crate::P256Sha256;
+
+lazy_static! {
+    pub static ref P256_SHA256: Value = serde_json::from_str(include_str!("vectors.json").trim())
+        .expect("Test vector is valid JSON");
+}
+
+#[allow(clippy::type_complexity)]
+#[allow(dead_code)]
+pub(crate) fn parse_test_vectors() -> (
+    VerifyingKey<P256Sha256>,
+    HashMap<u16, KeyPackage<P256Sha256>>,
+    &'static str,
+    Vec<u8>,
+    HashMap<u16, SigningNonces<P256Sha256>>,
+    HashMap<u16, SigningCommitments<P256Sha256>>,
+    Vec<u8>,
+    Rho<P256Sha256>,
+    HashMap<u16, SignatureShare<P256Sha256>>,
+    Vec<u8>, // Signature<P256Sha256>,
+) {
+    type R = P256Sha256;
+
+    let inputs = &P256_SHA256["inputs"];
+
+    let message = inputs["message"].as_str().unwrap();
+    let message_bytes = hex::decode(message).unwrap();
+
+    let mut key_packages: HashMap<u16, KeyPackage<R>> = HashMap::new();
+
+    let possible_signers = P256_SHA256["inputs"]["signers"].as_object().unwrap().iter();
+
+    let group_public =
+        VerifyingKey::<R>::from_hex(inputs["group_public_key"].as_str().unwrap()).unwrap();
+
+    for (i, secret_share) in possible_signers {
+        let secret = Secret::<R>::from_hex(secret_share["signer_share"].as_str().unwrap()).unwrap();
+        let signer_public = secret.into();
+
+        let key_package = KeyPackage::<R> {
+            index: u16::from_str(i).unwrap(),
+            secret_share: secret,
+            public: signer_public,
+            group_public,
+        };
+
+        key_packages.insert(*key_package.index(), key_package);
+    }
+
+    // Round one outputs
+
+    let round_one_outputs = &P256_SHA256["round_one_outputs"];
+
+    let group_binding_factor_input = Vec::<u8>::from_hex(
+        round_one_outputs["group_binding_factor_input"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap();
+
+    let group_binding_factor =
+        Rho::<R>::from_hex(round_one_outputs["group_binding_factor"].as_str().unwrap()).unwrap();
+
+    let mut signer_nonces: HashMap<u16, SigningNonces<R>> = HashMap::new();
+    let mut signer_commitments: HashMap<u16, SigningCommitments<R>> = HashMap::new();
+
+    for (i, signer) in round_one_outputs["signers"].as_object().unwrap().iter() {
+        let index = u16::from_str(i).unwrap();
+
+        let signing_nonces = SigningNonces::<R> {
+            hiding: Nonce::<R>::from_hex(signer["hiding_nonce"].as_str().unwrap()).unwrap(),
+            binding: Nonce::<R>::from_hex(signer["binding_nonce"].as_str().unwrap()).unwrap(),
+        };
+
+        signer_nonces.insert(index, signing_nonces);
+
+        let signing_commitments = SigningCommitments::<R> {
+            index,
+            hiding: NonceCommitment::from_hex(signer["hiding_nonce_commitment"].as_str().unwrap())
+                .unwrap(),
+            binding: NonceCommitment::from_hex(
+                signer["binding_nonce_commitment"].as_str().unwrap(),
+            )
+            .unwrap(),
+        };
+
+        signer_commitments.insert(index, signing_commitments);
+    }
+
+    // Round two outputs
+
+    let round_two_outputs = &P256_SHA256["round_two_outputs"];
+
+    let mut signature_shares: HashMap<u16, SignatureShare<R>> = HashMap::new();
+
+    for (i, signer) in round_two_outputs["signers"].as_object().unwrap().iter() {
+        let signature_share = SignatureShare::<R> {
+            index: u16::from_str(i).unwrap(),
+            signature: SignatureResponse {
+                z_share: Scalar::from_repr(*FieldBytes::from_slice(
+                    hex::decode(signer["sig_share"].as_str().unwrap())
+                        .unwrap()
+                        .as_slice(),
+                ))
+                .unwrap(),
+            },
+        };
+
+        signature_shares.insert(u16::from_str(i).unwrap(), signature_share);
+    }
+
+    // Final output
+
+    let final_output = &P256_SHA256["final_output"];
+
+    let signature_bytes = FromHex::from_hex(final_output["sig"].as_str().unwrap()).unwrap();
+
+    (
+        group_public,
+        key_packages,
+        message,
+        message_bytes,
+        signer_nonces,
+        signer_commitments,
+        group_binding_factor_input,
+        group_binding_factor,
+        signature_shares,
+        signature_bytes,
+    )
+}

--- a/frost-p256/tests/frost.rs
+++ b/frost-p256/tests/frost.rs
@@ -1,0 +1,93 @@
+use std::{collections::HashMap, convert::TryFrom};
+
+use frost_p256::*;
+use rand::thread_rng;
+
+#[test]
+fn check_sign_with_dealer() {
+    let mut rng = thread_rng();
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Key generation
+    ////////////////////////////////////////////////////////////////////////////
+
+    let numsigners = 5;
+    let threshold = 3;
+    let (shares, pubkeys) = keys::keygen_with_dealer(numsigners, threshold, &mut rng).unwrap();
+
+    // Verifies the secret shares from the dealer
+    let key_packages: Vec<keys::KeyPackage> = shares
+        .into_iter()
+        .map(|share| keys::KeyPackage::try_from(share).unwrap())
+        .collect();
+
+    let mut nonces: HashMap<u16, Vec<round1::SigningNonces>> = HashMap::new();
+    let mut commitments: HashMap<u16, Vec<round1::SigningCommitments>> = HashMap::new();
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Round 1: generating nonces and signing commitments for each participant
+    ////////////////////////////////////////////////////////////////////////////
+
+    for participant_index in 1..(threshold + 1) {
+        // Generate one (1) nonce and one SigningCommitments instance for each
+        // participant, up to _threshold_.
+        let (nonce, commitment) = round1::preprocess(1, participant_index as u16, &mut rng);
+        nonces.insert(participant_index as u16, nonce);
+        commitments.insert(participant_index as u16, commitment);
+    }
+
+    // This is what the signature aggregator / coordinator needs to do:
+    // - decide what message to sign
+    // - take one (unused) commitment per signing participant
+    let mut signature_shares: Vec<round2::SignatureShare> = Vec::new();
+    let message = "message to sign".as_bytes();
+    let comms = commitments.clone().into_values().flatten().collect();
+    let signing_package = SigningPackage::new(comms, message.to_vec());
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Round 2: each participant generates their signature share
+    ////////////////////////////////////////////////////////////////////////////
+
+    for participant_index in nonces.keys() {
+        let key_package = key_packages
+            .iter()
+            .find(|key_package| *participant_index == key_package.index)
+            .unwrap();
+
+        let nonces_to_use = &nonces.get(participant_index).unwrap()[0];
+
+        // Each participant generates their signature share.
+        let signature_share = round2::sign(&signing_package, nonces_to_use, key_package).unwrap();
+        signature_shares.push(signature_share);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Aggregation: collects the signing shares from all participants,
+    // generates the final signature.
+    ////////////////////////////////////////////////////////////////////////////
+
+    // Aggregate (also verifies the signature shares)
+    let group_signature_res = aggregate(&signing_package, &signature_shares[..], &pubkeys);
+
+    assert!(group_signature_res.is_ok());
+
+    let group_signature = group_signature_res.unwrap();
+
+    // Check that the threshold signature can be verified by the group public
+    // key (the verification key).
+    assert!(pubkeys
+        .group_public
+        .verify(message, &group_signature)
+        .is_ok());
+
+    // Check that the threshold signature can be verified by the group public
+    // key (the verification key) from SharePackage.group_public
+    for (participant_index, _) in nonces.clone() {
+        let key_package = key_packages.get(participant_index as usize).unwrap();
+
+        assert!(key_package
+            .group_public
+            .verify(message, &group_signature)
+            .is_ok());
+    }
+}

--- a/frost-p256/tests/proptests.rs
+++ b/frost-p256/tests/proptests.rs
@@ -1,0 +1,121 @@
+use frost_p256::*;
+use proptest::prelude::*;
+use rand_core::{CryptoRng, RngCore};
+
+/// A signature test-case, containing signature data and expected validity.
+#[derive(Clone, Debug)]
+struct SignatureCase {
+    msg: Vec<u8>,
+    sig: Signature,
+    vk: VerifyingKey,
+    invalid_vk: VerifyingKey,
+    is_valid: bool,
+}
+
+/// A modification to a test-case.
+#[derive(Copy, Clone, Debug)]
+enum Tweak {
+    /// No-op, used to check that unchanged cases verify.
+    None,
+    /// Change the message the signature is defined for, invalidating the signature.
+    ChangeMessage,
+    /// Change the public key the signature is defined for, invalidating the signature.
+    ChangePubkey,
+    /* XXX implement this -- needs to regenerate a custom signature because the
+       nonce commitment is fed into the hash, so it has to have torsion at signing
+       time.
+    /// Change the case to have a torsion component in the signature's `r` value.
+    AddTorsion,
+    */
+    /* XXX implement this -- needs custom handling of field arithmetic.
+    /// Change the signature's `s` scalar to be unreduced (mod L), invalidating the signature.
+    UnreducedScalar,
+    */
+}
+
+impl SignatureCase {
+    fn new<R: RngCore + CryptoRng>(mut rng: R, msg: Vec<u8>) -> Self {
+        let sk = SigningKey::new(&mut rng);
+        let sig = sk.sign(&mut rng, &msg);
+        let vk = VerifyingKey::from(&sk);
+        let invalid_vk = VerifyingKey::from(&SigningKey::new(&mut rng));
+        Self {
+            msg,
+            sig,
+            vk,
+            invalid_vk,
+            is_valid: true,
+        }
+    }
+
+    // Check that signature verification succeeds or fails, as expected.
+    fn check(&self) -> bool {
+        // The signature data is stored in (refined) byte types, but do a round trip
+        // conversion to raw bytes to exercise those code paths.
+        let _sig = {
+            let bytes = self.sig.to_bytes();
+            Signature::from_bytes(bytes)
+        };
+
+        // Check that the verification key is a valid key.
+        let _pub_key = VerifyingKey::from_bytes(self.vk.to_bytes())
+            .expect("The test verification key to be well-formed.");
+
+        // Check that signature validation has the expected result.
+        self.is_valid == self.vk.verify(&self.msg, &self.sig).is_ok()
+    }
+
+    fn apply_tweak(&mut self, tweak: &Tweak) {
+        match tweak {
+            Tweak::None => {}
+            Tweak::ChangeMessage => {
+                // Changing the message makes the signature invalid.
+                self.msg.push(90);
+                self.is_valid = false;
+            }
+            Tweak::ChangePubkey => {
+                // Changing the public key makes the signature invalid.
+                self.vk = self.invalid_vk;
+                self.is_valid = false;
+            }
+        }
+    }
+}
+
+fn tweak_strategy() -> impl Strategy<Value = Tweak> {
+    prop_oneof![
+        10 => Just(Tweak::None),
+        1 => Just(Tweak::ChangeMessage),
+        1 => Just(Tweak::ChangePubkey),
+    ]
+}
+
+use rand_chacha::ChaChaRng;
+use rand_core::SeedableRng;
+
+proptest! {
+
+    #[test]
+    fn tweak_signature(
+        tweaks in prop::collection::vec(tweak_strategy(), (0,5)),
+        rng_seed in prop::array::uniform32(any::<u8>()),
+    ) {
+        // Use a deterministic RNG so that test failures can be reproduced.
+        // Seeding with 64 bits of entropy is INSECURE and this code should
+        // not be copied outside of this test!
+        let mut rng = ChaChaRng::from_seed(rng_seed);
+
+        // Create a test case for each signature type.
+        let msg = b"test message for proptests";
+        let mut sig = SignatureCase::new(&mut rng, msg.to_vec());
+
+        // Apply tweaks to each case.
+        for t in &tweaks {
+            sig.apply_tweak(t);
+        }
+
+        assert!(sig.check());
+    }
+
+
+}


### PR DESCRIPTION
Adds P-256 support. Some notes:

- I didn't include a benchmark because they seem to be currently broken
- My first approach to represent the point encoding was `p256::Encoding`, which handles automatically the annoying identity encoding which takes a single byte. However that ends up causing other problems. I switched to a fixed array in 3c13b9cf. (I realized just after that V5 of the spec does specify that it should be a fixed-length array, so that's better anyway). The only uncertain thing is how the encode the identity, as we discussed in chat. For now I'm just padding it with zeroes.
- There's a lot of repetition in the tests, it's almost everything just a copy-and-paste of ristretto. I wonder if we should make them generic over the ciphersuite?