### PR TITLE
Expose internals to support randomization

### DIFF
--- a/frost-core/Cargo.toml
+++ b/frost-core/Cargo.toml
@@ -25,6 +25,7 @@ hex = { version = "0.4.3", features = ["serde"] }
 rand_core = "0.6"
 serde = { version = "1", optional = true, features = ["derive"] }
 thiserror = "1.0"
+visibility = "0.0.1"
 zeroize = { version = "1.5.4", default-features = false, features = ["derive"] }
 
 # Test dependencies used with the test-impl feature
@@ -46,3 +47,4 @@ nightly = []
 default = ["serde"]
 # Exposes ciphersuite-generic tests for other crates to use
 test-impl = ["proptest", "proptest-derive", "serde_json"]
+internals = []

--- a/frost-core/src/frost/identifier.rs
+++ b/frost-core/src/frost/identifier.rs
@@ -19,7 +19,8 @@ impl<C> Identifier<C>
 where
     C: Ciphersuite,
 {
-    // Serialize the underlying scalar.
+    /// Serialize the underlying scalar.
+    #[cfg_attr(feature = "internals", visibility::make(pub))]
     pub(crate) fn serialize(&self) -> <<C::Group as Group>::Field as Field>::Serialization {
         <<C::Group as Group>::Field>::serialize(&self.0)
     }

--- a/frost-core/src/frost/keys.rs
+++ b/frost-core/src/frost/keys.rs
@@ -121,6 +121,12 @@ impl<C> SigningShare<C>
 where
     C: Ciphersuite,
 {
+    /// Return the underlying scalar.
+    #[cfg(feature = "internals")]
+    pub fn to_scalar(self) -> <<<C as Ciphersuite>::Group as Group>::Field as Field>::Scalar {
+        self.0
+    }
+
     /// Deserialize from bytes
     pub fn from_bytes(
         bytes: <<C::Group as Group>::Field as Field>::Serialization,

--- a/frost-core/src/frost/round1.rs
+++ b/frost-core/src/frost/round1.rs
@@ -54,6 +54,12 @@ where
         Self(C::H3(input.as_slice()))
     }
 
+    /// Return the underlying scalar.
+    #[cfg(feature = "internals")]
+    pub fn to_scalar(self) -> <<<C as Ciphersuite>::Group as Group>::Field as Field>::Scalar {
+        self.0
+    }
+
     /// Deserialize [`Nonce`] from bytes
     pub fn from_bytes(
         bytes: <<C::Group as Group>::Field as Field>::Serialization,
@@ -100,6 +106,12 @@ impl<C> NonceCommitment<C>
 where
     C: Ciphersuite,
 {
+    /// Return the underlying element.
+    #[cfg(feature = "internals")]
+    pub fn to_element(self) -> <C::Group as Group>::Element {
+        self.0
+    }
+
     /// Deserialize [`NonceCommitment`] from bytes
     pub fn from_bytes(bytes: <C::Group as Group>::Serialization) -> Result<Self, Error> {
         <C::Group>::deserialize(&bytes).map(|element| Self(element))
@@ -221,6 +233,7 @@ where
     /// Computes the [signature commitment share] from these round one signing commitments.
     ///
     /// [signature commitment share]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#name-signature-share-verificatio
+    #[cfg_attr(feature = "internals", visibility::make(pub))]
     pub(super) fn to_group_commitment_share(
         self,
         binding_factor: &frost::BindingFactor<C>,
@@ -271,6 +284,7 @@ pub struct GroupCommitmentShare<C: Ciphersuite>(pub(super) Element<C>);
 /// - A byte string containing the serialized representation of B.
 ///
 /// [`encode_group_commitment_list()`]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#name-list-operations
+#[cfg_attr(feature = "internals", visibility::make(pub))]
 pub(super) fn encode_group_commitments<C: Ciphersuite>(
     signing_commitments: Vec<SigningCommitments<C>>,
 ) -> Vec<u8> {

--- a/frost-core/src/frost/round2.rs
+++ b/frost-core/src/frost/round2.rs
@@ -139,7 +139,7 @@ pub fn sign<C: Ciphersuite>(
         binding_factor_list[key_package.identifier].clone();
 
     // Compute the group commitment from signing commitments produced in round one.
-    let group_commitment = GroupCommitment::<C>::try_from(signing_package)?;
+    let group_commitment = compute_group_commitment(signing_package, &binding_factor_list)?;
 
     // Compute Lagrange coefficient.
     let lambda_i = frost::derive_lagrange_coeff(key_package.identifier(), signing_package)?;

--- a/frost-core/src/lib.rs
+++ b/frost-core/src/lib.rs
@@ -241,6 +241,17 @@ pub trait Ciphersuite: Copy + Clone + PartialEq {
 #[derive(Clone)]
 pub struct Challenge<C: Ciphersuite>(pub(crate) <<C::Group as Group>::Field as Field>::Scalar);
 
+impl<C> Challenge<C>
+where
+    C: Ciphersuite,
+{
+    /// Return the underlying scalar.
+    #[cfg(feature = "internals")]
+    pub fn to_scalar(self) -> <<<C as Ciphersuite>::Group as Group>::Field as Field>::Scalar {
+        self.0
+    }
+}
+
 impl<C> Debug for Challenge<C>
 where
     C: Ciphersuite,
@@ -263,6 +274,7 @@ where
 ///
 /// [FROST]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#name-signature-challenge-computa
 /// [RFC]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#section-3.2
+#[cfg_attr(feature = "internals", visibility::make(pub))]
 fn challenge<C>(R: &Element<C>, verifying_key: &Element<C>, msg: &[u8]) -> Challenge<C>
 where
     C: Ciphersuite,

--- a/frost-core/src/signature.rs
+++ b/frost-core/src/signature.rs
@@ -20,6 +20,15 @@ where
     C::Group: Group,
     <C::Group as Group>::Field: Field,
 {
+    /// Create a new Signature.
+    #[cfg(feature = "internals")]
+    pub fn new(
+        R: <C::Group as Group>::Element,
+        z: <<C::Group as Group>::Field as Field>::Scalar,
+    ) -> Self {
+        Self { R, z }
+    }
+
     /// Converts bytes as [`Ciphersuite::SignatureSerialization`] into a `Signature<C>`.
     pub fn from_bytes(bytes: C::SignatureSerialization) -> Result<Self, Error> {
         // To compute the expected length of the encoded point, encode the generator

--- a/frost-core/src/verifying_key.rs
+++ b/frost-core/src/verifying_key.rs
@@ -23,6 +23,18 @@ where
     //     VerifyingKey { element }
     // }
 
+    /// Create a new VerifyingKey from the given element.
+    #[cfg(feature = "internals")]
+    pub fn new(element: <C::Group as Group>::Element) -> Self {
+        Self { element }
+    }
+
+    /// Return the underlying element.
+    #[cfg(feature = "internals")]
+    pub fn to_element(self) -> <C::Group as Group>::Element {
+        self.element
+    }
+
     /// Deserialize from bytes
     pub fn from_bytes(bytes: <C::Group as Group>::Serialization) -> Result<VerifyingKey<C>, Error> {
         <C::Group>::deserialize(&bytes).map(|element| VerifyingKey { element })


### PR DESCRIPTION
Part of #121 along with https://github.com/ZcashFoundation/reddsa/pull/26

This implements the third option listed in #121. Some internal of frost-core are exposed under the "internals" feature (naming suggestions welcome) which allow implementing randomized FROST while reducing (but not eliminating) the amount of duplicated code.

