### PR TITLE
Fix clippy lints

### DIFF
--- a/frost-core/src/frost/identifier.rs
+++ b/frost-core/src/frost/identifier.rs
@@ -73,9 +73,7 @@ where
 
         let serialized = <<C::Group as Group>::Field as Field>::serialize(&id.0);
 
-        for i in 0..bytes.len() {
-            bytes[i] = serialized.as_ref()[i];
-        }
+        bytes.copy_from_slice(&serialized.as_ref()[..8]);
 
         usize::from_le_bytes(bytes)
     }

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -156,7 +156,7 @@ impl Ciphersuite for P256Sha256 {
     fn H1(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
         let mut u = [P256ScalarField::zero()];
         let dst = CONTEXT_STRING.to_owned() + "rho";
-        hash_to_field::<ExpandMsgXmd<Sha256>, Scalar>(&vec![m], dst.as_bytes(), &mut u)
+        hash_to_field::<ExpandMsgXmd<Sha256>, Scalar>(&[m], dst.as_bytes(), &mut u)
             .expect("should never return error according to error cases described in ExpandMsgXmd");
         u[0]
     }
@@ -167,7 +167,7 @@ impl Ciphersuite for P256Sha256 {
     fn H2(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
         let mut u = [P256ScalarField::zero()];
         let dst = CONTEXT_STRING.to_owned() + "chal";
-        hash_to_field::<ExpandMsgXmd<Sha256>, Scalar>(&vec![m], dst.as_bytes(), &mut u)
+        hash_to_field::<ExpandMsgXmd<Sha256>, Scalar>(&[m], dst.as_bytes(), &mut u)
             .expect("should never return error according to error cases described in ExpandMsgXmd");
         u[0]
     }
@@ -192,7 +192,7 @@ impl Ciphersuite for P256Sha256 {
     fn H4(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
         let mut u = [P256ScalarField::zero()];
         let dst = CONTEXT_STRING.to_owned() + "nonce";
-        hash_to_field::<ExpandMsgXmd<Sha256>, Scalar>(&vec![m], dst.as_bytes(), &mut u)
+        hash_to_field::<ExpandMsgXmd<Sha256>, Scalar>(&[m], dst.as_bytes(), &mut u)
             .expect("should never return error according to error cases described in ExpandMsgXmd");
         u[0]
     }
@@ -267,7 +267,7 @@ pub mod round2 {
         signer_nonces: &round1::SigningNonces,
         key_package: &keys::KeyPackage,
     ) -> Result<SignatureShare, &'static str> {
-        frost::round2::sign(&signing_package, signer_nonces, key_package)
+        frost::round2::sign(signing_package, signer_nonces, key_package)
     }
 }
 
@@ -280,7 +280,7 @@ pub fn aggregate(
     signature_shares: &[round2::SignatureShare],
     pubkeys: &keys::PublicKeyPackage,
 ) -> Result<Signature, &'static str> {
-    frost::aggregate(&signing_package, &signature_shares[..], &pubkeys)
+    frost::aggregate(signing_package, signature_shares, pubkeys)
 }
 
 ///

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -248,7 +248,7 @@ pub mod round2 {
         signer_nonces: &round1::SigningNonces,
         key_package: &keys::KeyPackage,
     ) -> Result<SignatureShare, &'static str> {
-        frost::round2::sign(&signing_package, signer_nonces, key_package)
+        frost::round2::sign(signing_package, signer_nonces, key_package)
     }
 }
 
@@ -261,7 +261,7 @@ pub fn aggregate(
     signature_shares: &[round2::SignatureShare],
     pubkeys: &keys::PublicKeyPackage,
 ) -> Result<Signature, &'static str> {
-    frost::aggregate(&signing_package, &signature_shares[..], &pubkeys)
+    frost::aggregate(signing_package, signature_shares, pubkeys)
 }
 
 ///


### PR DESCRIPTION
Depends on https://github.com/ZcashFoundation/frost/pull/87

Fix some clippy lints, but not all; there are a lot of them in `frost-redjujub` and I figured it wasn't worth fixing them since that code will be replaced in the future.