### PR TITLE
use Identifier instead of index

### DIFF
--- a/frost-core/src/frost.rs
+++ b/frost-core/src/frost.rs
@@ -102,7 +102,7 @@ fn derive_lagrange_coeff<C: Ciphersuite>(
     signer_id: &Identifier<C>,
     signing_package: &SigningPackage<C>,
 ) -> Result<<<C::Group as Group>::Field as Field>::Scalar, &'static str> {
-    let signer_id_scalar = signer_id.to_scalar();
+    let signer_id_scalar = signer_id.to_scalar()?;
 
     let zero = <<C::Group as Group>::Field as Field>::zero();
 
@@ -117,7 +117,7 @@ fn derive_lagrange_coeff<C: Ciphersuite>(
             continue;
         }
 
-        let commitment_id_scalar = commitment.identifier.to_scalar();
+        let commitment_id_scalar = commitment.identifier.to_scalar()?;
 
         num = num * commitment_id_scalar;
         den = den * (commitment_id_scalar - signer_id_scalar);

--- a/frost-core/src/frost/identifier.rs
+++ b/frost-core/src/frost/identifier.rs
@@ -24,7 +24,12 @@ where
     //
     // Ideally this would be a From<Identifier<C>> for Scalar<C> impl, but rustc
     // doesn't like that
-    pub(crate) fn to_scalar(self) -> Scalar<C> {
+    pub(crate) fn to_scalar(self) -> Result<Scalar<C>, &'static str> {
+        // This should never happen since we check it when building Identifier,
+        // but we check again out of abundance of caution.
+        if self.0 == 0 {
+            return Err("Identifier must not be zero");
+        }
         // Classic left-to-right double-and-add algorithm that skips the first bit 1 (since
         // identifiers are never zero, there is always a bit 1), thus `sum` starts with 1 too.
         let one = <<C::Group as Group>::Field as Field>::one();
@@ -37,7 +42,7 @@ where
                 sum = sum + one;
             }
         }
-        sum
+        Ok(sum)
     }
 }
 

--- a/frost-core/src/frost/identifier.rs
+++ b/frost-core/src/frost/identifier.rs
@@ -29,6 +29,7 @@ where
         // identifiers are never zero, there is always a bit 1), thus `sum` starts with 1 too.
         let one = <<C::Group as Group>::Field as Field>::one();
         let mut sum = <<C::Group as Group>::Field as Field>::one();
+
         let bits = (self.0.to_be_bytes().len() as u32) * 8;
         for i in (0..(bits - self.0.leading_zeros() - 1)).rev() {
             sum = sum + sum;

--- a/frost-core/src/frost/identifier.rs
+++ b/frost-core/src/frost/identifier.rs
@@ -14,7 +14,7 @@ use crate::{Ciphersuite, Error, Field, Group, Scalar};
 /// over, corresponding to some x-coordinate for a polynomial f(x) = y.  MUST NOT be zero in the
 /// field, as f(0) = the shared secret.
 #[derive(Copy, Clone)]
-pub struct Identifier<C>(pub(crate) u16, PhantomData<C>);
+pub struct Identifier<C>(u16, PhantomData<C>);
 
 impl<C> Identifier<C>
 where

--- a/frost-core/src/frost/identifier.rs
+++ b/frost-core/src/frost/identifier.rs
@@ -21,6 +21,9 @@ where
     C: Ciphersuite,
 {
     // Convert the identifier to a Scalar.
+    //
+    // Ideally this would be a From<Identifier<C>> for Scalar<C> impl, but rustc
+    // doesn't like that
     pub(crate) fn to_scalar(self) -> Scalar<C> {
         // Classic left-to-right double-and-add algorithm that skips the first bit 1 (since
         // identifiers are never zero, there is always a bit 1), thus `sum` starts with 1 too.

--- a/frost-core/src/frost/identifier.rs
+++ b/frost-core/src/frost/identifier.rs
@@ -3,7 +3,7 @@
 use std::{
     fmt::{self, Debug},
     hash::{Hash, Hasher},
-    ops::{Deref, Index},
+    marker::PhantomData,
 };
 
 use crate::{Ciphersuite, Error, Field, Group, Scalar};
@@ -14,14 +14,46 @@ use crate::{Ciphersuite, Error, Field, Group, Scalar};
 /// over, corresponding to some x-coordinate for a polynomial f(x) = y.  MUST NOT be zero in the
 /// field, as f(0) = the shared secret.
 #[derive(Copy, Clone)]
-pub struct Identifier<C: Ciphersuite>(pub(crate) Scalar<C>);
+pub struct Identifier<C>(pub(crate) u16, PhantomData<C>);
 
-impl<C> AsRef<Scalar<C>> for Identifier<C>
+impl<C> Identifier<C>
 where
     C: Ciphersuite,
 {
-    fn as_ref(&self) -> &Scalar<C> {
-        &self.0
+    // Convert the identifier to a Scalar.
+    pub(crate) fn to_scalar(self) -> Scalar<C> {
+        // Classic left-to-right double-and-add algorithm that skips the first bit 1 (since
+        // identifiers are never zero, there is always a bit 1), thus `sum` starts with 1 too.
+        let one = <<C::Group as Group>::Field as Field>::one();
+        let mut sum = <<C::Group as Group>::Field as Field>::one();
+        let bits = (self.0.to_be_bytes().len() as u32) * 8;
+        for i in (0..(bits - self.0.leading_zeros() - 1)).rev() {
+            sum = sum + sum;
+            if self.0 & (1 << i) != 0 {
+                sum = sum + one;
+            }
+        }
+        sum
+    }
+}
+
+impl<C> PartialEq for Identifier<C> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<C> Eq for Identifier<C> {}
+
+impl<C> PartialOrd for Identifier<C> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl<C> Ord for Identifier<C> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
     }
 }
 
@@ -30,52 +62,7 @@ where
     C: Ciphersuite,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_tuple("Identifier")
-            .field(&usize::from(*self))
-            .finish()
-    }
-}
-
-impl<C> Deref for Identifier<C>
-where
-    C: Ciphersuite,
-{
-    type Target = Scalar<C>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-// impl<C> Deref for &Identifier<C>
-// where
-//     C: Ciphersuite,
-// {
-//     type Target = Scalar<C>;
-
-//     fn deref(&self) -> &Self::Target {
-//         &self.0
-//     }
-// }
-
-impl<C> Eq for Identifier<C> where C: Ciphersuite {}
-
-impl<C> From<Identifier<C>> for usize
-where
-    C: Ciphersuite,
-{
-    // TODO: this feels janky, are we confident we aren't clamping off the higher byte values?
-    fn from(id: Identifier<C>) -> usize {
-        // This is 8 bytes because usize is up to 8 bytes depending on the platform.
-        //
-        // https://doc.rust-lang.org/stable/std/primitive.usize.html#method.from_le_bytes
-        let mut bytes = [0u8; 8];
-
-        let serialized = <<C::Group as Group>::Field as Field>::serialize(&id.0);
-
-        bytes.copy_from_slice(&serialized.as_ref()[..8]);
-
-        usize::from_le_bytes(bytes)
+        f.debug_tuple("Identifier").field(&self.0).finish()
     }
 }
 
@@ -84,86 +71,18 @@ where
     C: Ciphersuite,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        <<C::Group as Group>::Field as Field>::serialize(&self.0)
-            .as_ref()
-            .hash(state)
+        self.0.hash(state)
     }
 }
 
-impl<C, T> Index<Identifier<C>> for Vec<T>
+impl<C> From<Identifier<C>> for u16
 where
     C: Ciphersuite,
 {
-    type Output = T;
-
-    fn index(&self, id: Identifier<C>) -> &Self::Output {
-        &self[usize::from(id)]
+    fn from(identifier: Identifier<C>) -> Self {
+        identifier.0
     }
 }
-
-// impl<C> std::ops::Mul for Identifier<C>
-// where
-//     C: Ciphersuite,
-// {
-//     type Output = Self;
-
-//     fn mul(self, rhs: Identifier<C>) -> Self::Output {
-//         Self(self.0 * rhs.0)
-//     }
-// }
-
-// impl<C> std::ops::Mul<Scalar<C>> for Identifier<C>
-// where
-//     C: Ciphersuite,
-// {
-//     type Output = Scalar<C>;
-
-//     fn mul(self, scalar: Scalar<C>) -> Scalar<C> {
-//         self.0 * scalar
-//     }
-// }
-
-// impl<'a, 'b, C> std::ops::Mul<&'b Identifier<C>> for &'a Scalar<C>
-// where
-//     C: Ciphersuite,
-// {
-//     type Output = Scalar<C>;
-
-//     fn mul(self, id: &'b Identifier<C>) -> Scalar<C> {
-//         self * id.0
-//     }
-// }
-
-impl<C> PartialEq for Identifier<C>
-where
-    C: Ciphersuite,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-// impl<C> std::ops::Sub for Identifier<C>
-// where
-//     C: Ciphersuite,
-// {
-//     type Output = Self;
-
-//     fn sub(self, rhs: Identifier<C>) -> Self::Output {
-//         Self(self.0 - rhs.0)
-//     }
-// }
-
-// impl<C> std::ops::Sub<Scalar<C>> for Identifier<C>
-// where
-//     C: Ciphersuite,
-// {
-//     type Output = Scalar<C>;
-
-//     fn sub(self, scalar: Scalar<C>) -> Scalar<C> {
-//         self.0 - scalar
-//     }
-// }
 
 impl<C> TryFrom<u16> for Identifier<C>
 where
@@ -171,26 +90,11 @@ where
 {
     type Error = Error;
 
-    // TODO: this feels like a cluster. Improve?
     fn try_from(n: u16) -> Result<Identifier<C>, Self::Error> {
-        let mut bytes =
-            Vec::from(<<C::Group as Group>::Field as Field>::Serialization::default().as_ref());
-
-        for (i, byte) in n.to_le_bytes().iter().enumerate() {
-            bytes[i] = *byte;
-        }
-
-        let serialization = bytes
-            .try_into()
-            .map_err(|_| Self::Error::MalformedIdentifier)?;
-
-        let scalar = <<C::Group as Group>::Field as Field>::deserialize(&serialization)?;
-
-        // Participant identifiers are public, so this comparison doesn't need to be constant-time.
-        if scalar == <<C::Group as Group>::Field as Field>::zero() {
+        if n == 0 {
             Err(Self::Error::InvalidZeroScalar)
         } else {
-            Ok(Self(scalar))
+            Ok(Self(n, Default::default()))
         }
     }
 }

--- a/frost-core/src/frost/keys.rs
+++ b/frost-core/src/frost/keys.rs
@@ -207,7 +207,7 @@ where
     pub fn verify(&self) -> Result<(), &'static str> {
         let f_result = <C::Group as Group>::generator() * self.value.0;
 
-        let x = self.identifier.to_scalar();
+        let x = self.identifier.to_scalar()?;
 
         let (_, result) = self.commitment.0.iter().fold(
             (
@@ -441,7 +441,7 @@ pub fn generate_secret_shares<C: Ciphersuite, R: RngCore + CryptoRng>(
     // using Horner's method.
     for id in (1..=numshares as u16).map_while(|i| Identifier::<C>::try_from(i).ok()) {
         let mut value = <<C::Group as Group>::Field as Field>::zero();
-        let id_scalar = id.to_scalar();
+        let id_scalar = id.to_scalar()?;
 
         // Polynomial evaluation, for this identifier
         //
@@ -483,13 +483,13 @@ pub fn reconstruct_secret<C: Ciphersuite>(
     for (i, secret_share) in secret_share_map.clone() {
         let mut num = <<C::Group as Group>::Field as Field>::one();
         let mut den = <<C::Group as Group>::Field as Field>::one();
-        let i_scalar = i.to_scalar();
+        let i_scalar = i.to_scalar()?;
 
         for j in secret_share_map.clone().into_keys() {
             if j == i {
                 continue;
             }
-            let j_scalar = j.to_scalar();
+            let j_scalar = j.to_scalar()?;
 
             // numerator *= j
             num = num * j_scalar;

--- a/frost-core/src/frost/round2.rs
+++ b/frost-core/src/frost/round2.rs
@@ -60,8 +60,8 @@ where
 /// shares into the joint signature.
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub struct SignatureShare<C: Ciphersuite> {
-    /// Represents the participant index.
-    pub index: u16,
+    /// Represents the participant identifier.
+    pub identifier: Identifier<C>,
     /// This participant's signature over the message.
     pub signature: SignatureResponse<C>,
 }
@@ -70,9 +70,9 @@ impl<C> SignatureShare<C>
 where
     C: Ciphersuite,
 {
-    /// Gets the participant index associated with this [`SignatureShare`].
-    pub fn index(&self) -> &u16 {
-        &self.index
+    /// Gets the participant identifier associated with this [`SignatureShare`].
+    pub fn identifier(&self) -> &Identifier<C> {
+        &self.identifier
     }
 
     /// Tests if a signature share issued by a participant is valid before
@@ -104,7 +104,7 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("SignatureShare")
-            .field("index", &self.index)
+            .field("identifier", &self.identifier)
             .field("signature", &self.signature)
             .finish()
     }
@@ -141,7 +141,7 @@ pub fn sign<C: Ciphersuite>(
     let group_commitment = GroupCommitment::<C>::try_from(signing_package)?;
 
     // Compute Lagrange coefficient.
-    let lambda_i = frost::derive_lagrange_coeff(*key_package.index(), signing_package)?;
+    let lambda_i = frost::derive_lagrange_coeff(key_package.identifier(), signing_package)?;
 
     // Compute the per-message challenge.
     let challenge = challenge::<C>(
@@ -156,7 +156,7 @@ pub fn sign<C: Ciphersuite>(
         + (lambda_i * key_package.secret_share.0 * challenge.0);
 
     let signature_share = SignatureShare::<C> {
-        index: *key_package.index(),
+        identifier: *key_package.identifier(),
         signature: SignatureResponse::<C> { z_share },
     };
 

--- a/frost-core/tests/common/vectors.rs
+++ b/frost-core/tests/common/vectors.rs
@@ -22,14 +22,14 @@ lazy_static! {
 #[allow(dead_code)]
 pub(crate) fn parse_test_vectors() -> (
     VerifyingKey<Ristretto255Sha512>,
-    HashMap<u16, KeyPackage<Ristretto255Sha512>>,
+    HashMap<Identifier<Ristretto255Sha512>, KeyPackage<Ristretto255Sha512>>,
     &'static str,
     Vec<u8>,
-    HashMap<u16, SigningNonces<Ristretto255Sha512>>,
-    HashMap<u16, SigningCommitments<Ristretto255Sha512>>,
+    HashMap<Identifier<Ristretto255Sha512>, SigningNonces<Ristretto255Sha512>>,
+    HashMap<Identifier<Ristretto255Sha512>, SigningCommitments<Ristretto255Sha512>>,
     Vec<u8>,
     Rho<Ristretto255Sha512>,
-    HashMap<u16, SignatureShare<Ristretto255Sha512>>,
+    HashMap<Identifier<Ristretto255Sha512>, SignatureShare<Ristretto255Sha512>>,
     Vec<u8>, // Signature<Ristretto255Sha512>,
 ) {
     type R = Ristretto255Sha512;
@@ -39,7 +39,7 @@ pub(crate) fn parse_test_vectors() -> (
     let message = inputs["message"].as_str().unwrap();
     let message_bytes = hex::decode(message).unwrap();
 
-    let mut key_packages: HashMap<u16, KeyPackage<R>> = HashMap::new();
+    let mut key_packages: HashMap<Identifier<Ristretto255Sha512>, KeyPackage<R>> = HashMap::new();
 
     let possible_signers = RISTRETTO255_SHA512["inputs"]["signers"]
         .as_object()
@@ -54,13 +54,13 @@ pub(crate) fn parse_test_vectors() -> (
         let signer_public = secret.into();
 
         let key_package = KeyPackage::<R> {
-            index: u16::from_str(i).unwrap(),
+            identifier: u16::from_str(i).unwrap().try_into().unwrap(),
             secret_share: secret,
             public: signer_public,
             group_public,
         };
 
-        key_packages.insert(*key_package.index(), key_package);
+        key_packages.insert(*key_package.identifier(), key_package);
     }
 
     // Round one outputs
@@ -77,21 +77,21 @@ pub(crate) fn parse_test_vectors() -> (
     let group_binding_factor =
         Rho::<R>::from_hex(round_one_outputs["group_binding_factor"].as_str().unwrap()).unwrap();
 
-    let mut signer_nonces: HashMap<u16, SigningNonces<R>> = HashMap::new();
-    let mut signer_commitments: HashMap<u16, SigningCommitments<R>> = HashMap::new();
+    let mut signer_nonces: HashMap<Identifier<R>, SigningNonces<R>> = HashMap::new();
+    let mut signer_commitments: HashMap<Identifier<R>, SigningCommitments<R>> = HashMap::new();
 
     for (i, signer) in round_one_outputs["signers"].as_object().unwrap().iter() {
-        let index = u16::from_str(i).unwrap();
+        let identifier = u16::from_str(i).unwrap().try_into().unwrap();
 
         let signing_nonces = SigningNonces::<R> {
             hiding: Nonce::<R>::from_hex(signer["hiding_nonce"].as_str().unwrap()).unwrap(),
             binding: Nonce::<R>::from_hex(signer["binding_nonce"].as_str().unwrap()).unwrap(),
         };
 
-        signer_nonces.insert(index, signing_nonces);
+        signer_nonces.insert(identifier, signing_nonces);
 
         let signing_commitments = SigningCommitments::<R> {
-            index,
+            identifier,
             hiding: NonceCommitment::from_hex(signer["hiding_nonce_commitment"].as_str().unwrap())
                 .unwrap(),
             binding: NonceCommitment::from_hex(
@@ -100,18 +100,18 @@ pub(crate) fn parse_test_vectors() -> (
             .unwrap(),
         };
 
-        signer_commitments.insert(index, signing_commitments);
+        signer_commitments.insert(identifier, signing_commitments);
     }
 
     // Round two outputs
 
     let round_two_outputs = &RISTRETTO255_SHA512["round_two_outputs"];
 
-    let mut signature_shares: HashMap<u16, SignatureShare<R>> = HashMap::new();
+    let mut signature_shares: HashMap<Identifier<R>, SignatureShare<R>> = HashMap::new();
 
     for (i, signer) in round_two_outputs["signers"].as_object().unwrap().iter() {
         let signature_share = SignatureShare::<R> {
-            index: u16::from_str(i).unwrap(),
+            identifier: u16::from_str(i).unwrap().try_into().unwrap(),
             signature: SignatureResponse {
                 z_share: Scalar::from_canonical_bytes(
                     hex::decode(signer["sig_share"].as_str().unwrap())
@@ -123,7 +123,10 @@ pub(crate) fn parse_test_vectors() -> (
             },
         };
 
-        signature_shares.insert(u16::from_str(i).unwrap(), signature_share);
+        signature_shares.insert(
+            u16::from_str(i).unwrap().try_into().unwrap(),
+            signature_share,
+        );
     }
 
     // Final output

--- a/frost-core/tests/tests.rs
+++ b/frost-core/tests/tests.rs
@@ -1,4 +1,4 @@
-use frost_core::frost;
+use frost_core::frost::{self};
 use rand::thread_rng;
 
 mod common;
@@ -93,9 +93,9 @@ fn check_sign_with_test_vectors() {
     let mut our_signature_shares: Vec<frost::round2::SignatureShare<R>> = Vec::new();
 
     // Each participant generates their signature share
-    for index in signer_nonces.keys() {
-        let key_package = &key_packages[index];
-        let nonces = &signer_nonces[index];
+    for identifier in signer_nonces.keys() {
+        let key_package = &key_packages[identifier];
+        let nonces = &signer_nonces[identifier];
 
         // Each participant generates their signature share.
         let signature_share = frost::round2::sign(&signing_package, nonces, key_package).unwrap();
@@ -104,7 +104,7 @@ fn check_sign_with_test_vectors() {
     }
 
     for sig_share in our_signature_shares.clone() {
-        assert_eq!(sig_share, signature_shares[sig_share.index()]);
+        assert_eq!(sig_share, signature_shares[sig_share.identifier()]);
     }
 
     let signer_pubkeys = key_packages
@@ -150,3 +150,18 @@ fn check_sign_with_test_vectors() {
     let group_signature = group_signature_result.unwrap();
     assert_eq!(group_signature.to_bytes().to_vec(), signature_bytes);
 }
+
+// This allows checking that to_scalar() works for all possible inputs;
+// but requires making to_scalar() public.
+// #[test]
+// fn test_identifier_to_scalar() {
+//     type R = Ristretto255Sha512;
+
+//     let one = <<<R as Ciphersuite>::Group as Group>::Field as Field>::one();
+//     let mut sum = <<<R as Ciphersuite>::Group as Group>::Field as Field>::one();
+//     for i in 1..0xFFFFu16 {
+//         let identifier: Identifier<R> = i.try_into().unwrap();
+//         assert_eq!(sum, identifier.to_scalar());
+//         sum = sum + one;
+//     }
+// }

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -202,6 +202,9 @@ impl Ciphersuite for P256Sha256 {
 type P = P256Sha256;
 
 ///
+pub type Identifier = frost::Identifier<P>;
+
+///
 pub mod keys {
     use super::*;
 
@@ -237,14 +240,14 @@ pub mod round1 {
 
     ///
     pub fn commit<RNG>(
-        participant_index: u16,
+        participant_identifier: frost::Identifier<P>,
         secret: &Secret<P>,
         rng: &mut RNG,
     ) -> (SigningNonces, SigningCommitments)
     where
         RNG: CryptoRng + RngCore,
     {
-        frost::round1::commit::<P, RNG>(participant_index, secret, rng)
+        frost::round1::commit::<P, RNG>(participant_identifier, secret, rng)
     }
 }
 

--- a/frost-p256/src/tests.rs
+++ b/frost-p256/src/tests.rs
@@ -94,9 +94,9 @@ fn check_sign_with_test_vectors() {
     let mut our_signature_shares: Vec<frost::round2::SignatureShare<R>> = Vec::new();
 
     // Each participant generates their signature share
-    for index in signer_nonces.keys() {
-        let key_package = &key_packages[index];
-        let nonces = &signer_nonces[index];
+    for identifier in signer_nonces.keys() {
+        let key_package = &key_packages[identifier];
+        let nonces = &signer_nonces[identifier];
 
         // Each participant generates their signature share.
         let signature_share = frost::round2::sign(&signing_package, nonces, key_package).unwrap();
@@ -105,7 +105,7 @@ fn check_sign_with_test_vectors() {
     }
 
     for sig_share in our_signature_shares.clone() {
-        assert_eq!(sig_share, signature_shares[sig_share.index()]);
+        assert_eq!(sig_share, signature_shares[sig_share.identifier()]);
     }
 
     let signer_pubkeys = key_packages

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -183,6 +183,9 @@ impl Ciphersuite for Ristretto255Sha512 {
 type R = Ristretto255Sha512;
 
 ///
+pub type Identifier = frost::Identifier<R>;
+
+///
 pub mod keys {
     use super::*;
 
@@ -218,14 +221,14 @@ pub mod round1 {
 
     ///
     pub fn commit<RNG>(
-        participant_index: u16,
+        participant_identifier: frost::Identifier<R>,
         secret: &Secret<R>,
         rng: &mut RNG,
     ) -> (SigningNonces, SigningCommitments)
     where
         RNG: CryptoRng + RngCore,
     {
-        frost::round1::commit::<R, RNG>(participant_index, secret, rng)
+        frost::round1::commit::<R, RNG>(participant_identifier, secret, rng)
     }
 }
 

--- a/frost-ristretto255/src/tests.rs
+++ b/frost-ristretto255/src/tests.rs
@@ -94,9 +94,9 @@ fn check_sign_with_test_vectors() {
     let mut our_signature_shares: Vec<frost::round2::SignatureShare<R>> = Vec::new();
 
     // Each participant generates their signature share
-    for index in signer_nonces.keys() {
-        let key_package = &key_packages[index];
-        let nonces = &signer_nonces[index];
+    for identifier in signer_nonces.keys() {
+        let key_package = &key_packages[identifier];
+        let nonces = &signer_nonces[identifier];
 
         // Each participant generates their signature share.
         let signature_share = frost::round2::sign(&signing_package, nonces, key_package).unwrap();
@@ -105,7 +105,7 @@ fn check_sign_with_test_vectors() {
     }
 
     for sig_share in our_signature_shares.clone() {
-        assert_eq!(sig_share, signature_shares[sig_share.index()]);
+        assert_eq!(sig_share, signature_shares[sig_share.identifier()]);
     }
 
     let signer_pubkeys = key_packages

--- a/frost-ristretto255/src/tests/vectors.rs
+++ b/frost-ristretto255/src/tests/vectors.rs
@@ -22,14 +22,14 @@ lazy_static! {
 #[allow(dead_code)]
 pub(crate) fn parse_test_vectors() -> (
     VerifyingKey<Ristretto255Sha512>,
-    HashMap<u16, KeyPackage<Ristretto255Sha512>>,
+    HashMap<Identifier<Ristretto255Sha512>, KeyPackage<Ristretto255Sha512>>,
     &'static str,
     Vec<u8>,
-    HashMap<u16, SigningNonces<Ristretto255Sha512>>,
-    HashMap<u16, SigningCommitments<Ristretto255Sha512>>,
+    HashMap<Identifier<Ristretto255Sha512>, SigningNonces<Ristretto255Sha512>>,
+    HashMap<Identifier<Ristretto255Sha512>, SigningCommitments<Ristretto255Sha512>>,
     Vec<u8>,
     Rho<Ristretto255Sha512>,
-    HashMap<u16, SignatureShare<Ristretto255Sha512>>,
+    HashMap<Identifier<Ristretto255Sha512>, SignatureShare<Ristretto255Sha512>>,
     Vec<u8>, // Signature<Ristretto255Sha512>,
 ) {
     type R = Ristretto255Sha512;
@@ -39,7 +39,7 @@ pub(crate) fn parse_test_vectors() -> (
     let message = inputs["message"].as_str().unwrap();
     let message_bytes = hex::decode(message).unwrap();
 
-    let mut key_packages: HashMap<u16, KeyPackage<R>> = HashMap::new();
+    let mut key_packages: HashMap<Identifier<Ristretto255Sha512>, KeyPackage<R>> = HashMap::new();
 
     let possible_signers = RISTRETTO255_SHA512["inputs"]["signers"]
         .as_object()
@@ -54,13 +54,13 @@ pub(crate) fn parse_test_vectors() -> (
         let signer_public = secret.into();
 
         let key_package = KeyPackage::<R> {
-            index: u16::from_str(i).unwrap(),
+            identifier: u16::from_str(i).unwrap().try_into().unwrap(),
             secret_share: secret,
             public: signer_public,
             group_public,
         };
 
-        key_packages.insert(*key_package.index(), key_package);
+        key_packages.insert(*key_package.identifier(), key_package);
     }
 
     // Round one outputs
@@ -77,21 +77,21 @@ pub(crate) fn parse_test_vectors() -> (
     let group_binding_factor =
         Rho::<R>::from_hex(round_one_outputs["group_binding_factor"].as_str().unwrap()).unwrap();
 
-    let mut signer_nonces: HashMap<u16, SigningNonces<R>> = HashMap::new();
-    let mut signer_commitments: HashMap<u16, SigningCommitments<R>> = HashMap::new();
+    let mut signer_nonces: HashMap<Identifier<R>, SigningNonces<R>> = HashMap::new();
+    let mut signer_commitments: HashMap<Identifier<R>, SigningCommitments<R>> = HashMap::new();
 
     for (i, signer) in round_one_outputs["signers"].as_object().unwrap().iter() {
-        let index = u16::from_str(i).unwrap();
+        let identifier = u16::from_str(i).unwrap().try_into().unwrap();
 
         let signing_nonces = SigningNonces::<R> {
             hiding: Nonce::<R>::from_hex(signer["hiding_nonce"].as_str().unwrap()).unwrap(),
             binding: Nonce::<R>::from_hex(signer["binding_nonce"].as_str().unwrap()).unwrap(),
         };
 
-        signer_nonces.insert(index, signing_nonces);
+        signer_nonces.insert(identifier, signing_nonces);
 
         let signing_commitments = SigningCommitments::<R> {
-            index,
+            identifier,
             hiding: NonceCommitment::from_hex(signer["hiding_nonce_commitment"].as_str().unwrap())
                 .unwrap(),
             binding: NonceCommitment::from_hex(
@@ -100,18 +100,18 @@ pub(crate) fn parse_test_vectors() -> (
             .unwrap(),
         };
 
-        signer_commitments.insert(index, signing_commitments);
+        signer_commitments.insert(identifier, signing_commitments);
     }
 
     // Round two outputs
 
     let round_two_outputs = &RISTRETTO255_SHA512["round_two_outputs"];
 
-    let mut signature_shares: HashMap<u16, SignatureShare<R>> = HashMap::new();
+    let mut signature_shares: HashMap<Identifier<R>, SignatureShare<R>> = HashMap::new();
 
     for (i, signer) in round_two_outputs["signers"].as_object().unwrap().iter() {
         let signature_share = SignatureShare::<R> {
-            index: u16::from_str(i).unwrap(),
+            identifier: u16::from_str(i).unwrap().try_into().unwrap(),
             signature: SignatureResponse {
                 z_share: Scalar::from_canonical_bytes(
                     hex::decode(signer["sig_share"].as_str().unwrap())
@@ -123,7 +123,10 @@ pub(crate) fn parse_test_vectors() -> (
             },
         };
 
-        signature_shares.insert(u16::from_str(i).unwrap(), signature_share);
+        signature_shares.insert(
+            u16::from_str(i).unwrap().try_into().unwrap(),
+            signature_share,
+        );
     }
 
     // Final output


### PR DESCRIPTION
Requires #88 

Closes #55 

Things I'm not sure about:

- The commented out `test_identifier_to_scalar` test: should I delete it? Should we make `to_scalar()` public?
- Should we add a `identifier_to_scalar()` method to the trait, and add the implementation in this PR as a default implementation?
