### PR TITLE
Make verification per-ciphersuite

### DIFF
--- a/frost-core/src/batch.rs
+++ b/frost-core/src/batch.rs
@@ -50,7 +50,7 @@ where
     /// requires borrowing the message data, the `Item` type is unlinked
     /// from the lifetime of the message.
     pub fn verify_single(self) -> Result<(), Error> {
-        verify_prehashed::<C>(self.c, &self.sig, &self.vk)
+        self.vk.verify_prehashed(self.c, &self.sig)
     }
 }
 

--- a/frost-core/src/batch.rs
+++ b/frost-core/src/batch.rs
@@ -50,7 +50,7 @@ where
     /// requires borrowing the message data, the `Item` type is unlinked
     /// from the lifetime of the message.
     pub fn verify_single(self) -> Result<(), Error> {
-        self.vk.verify_prehashed(&self.sig, self.c)
+        verify_prehashed::<C>(self.c, &self.sig, &self.vk)
     }
 }
 

--- a/frost-core/src/frost.rs
+++ b/frost-core/src/frost.rs
@@ -33,7 +33,7 @@ pub use self::identifier::Identifier;
 /// of commitments, and a specific message.
 ///
 /// <https://github.com/cfrg/draft-irtf-cfrg-frost/blob/master/draft-irtf-cfrg-frost.md>
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Rho<C: Ciphersuite>(<<C::Group as Group>::Field as Field>::Scalar);
 
 impl<C> Rho<C>
@@ -199,7 +199,7 @@ where
 
 /// The product of all signers' individual commitments, published as part of the
 /// final signature.
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub struct GroupCommitment<C: Ciphersuite>(pub(super) <C::Group as Group>::Element);
 
 // impl<C> Debug for GroupCommitment<C> where C: Ciphersuite {

--- a/frost-core/src/frost/keys.rs
+++ b/frost-core/src/frost/keys.rs
@@ -14,7 +14,7 @@ use zeroize::{DefaultIsZeroes, Zeroize};
 use crate::{frost::Identifier, Ciphersuite, Error, Field, Group, Scalar, VerifyingKey};
 
 /// A secret scalar value representing a signer's secret key.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Secret<C: Ciphersuite>(pub(crate) Scalar<C>);
 
 impl<C> Secret<C>
@@ -104,7 +104,7 @@ where
 }
 
 /// A public group element that represents a single signer's public key.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Public<C>(pub(super) <C::Group as Group>::Element)
 where
     C: Ciphersuite;

--- a/frost-core/src/frost/round1.rs
+++ b/frost-core/src/frost/round1.rs
@@ -11,7 +11,7 @@ use crate::{frost, Ciphersuite, Error, Field, Group};
 use super::{keys::Secret, Identifier};
 
 /// A scalar that is a signing nonce.
-#[derive(Clone, PartialEq, Zeroize)]
+#[derive(Clone, PartialEq, Eq, Zeroize)]
 pub struct Nonce<C: Ciphersuite>(pub(super) <<C::Group as Group>::Field as Field>::Scalar);
 
 impl<C> Nonce<C>

--- a/frost-core/src/lib.rs
+++ b/frost-core/src/lib.rs
@@ -26,28 +26,6 @@ pub use signature::Signature;
 pub use signing_key::SigningKey;
 pub use verifying_key::VerifyingKey;
 
-/// Verify a purported `signature` with a pre-hashed [`Challenge`] made by this verification
-/// key.
-pub(crate) fn verify_prehashed<C: Ciphersuite>(
-    challenge: Challenge<C>,
-    signature: &Signature<C>,
-    public_key: &VerifyingKey<C>,
-) -> Result<(), Error> {
-    // Verify check is h * ( - z * B + R  + c * A) == 0
-    //                 h * ( z * B - c * A - R) == 0
-    //
-    // where h is the cofactor
-    let zB = C::Group::generator() * signature.z;
-    let cA = public_key.element * challenge.0;
-    let check = (zB - cA - signature.R) * C::Group::cofactor();
-
-    if check == C::Group::identity() {
-        Ok(())
-    } else {
-        Err(Error::InvalidSignature)
-    }
-}
-
 /// A prime order finite field GF(q) over which all scalar values for our prime order group can be
 /// multiplied are defined.
 ///
@@ -232,7 +210,7 @@ pub trait Ciphersuite: Copy + Clone {
     ) -> Result<(), Error> {
         let c = crate::challenge::<Self>(&signature.R, &public_key.element, msg);
 
-        verify_prehashed(c, signature, public_key)
+        public_key.verify_prehashed(c, signature)
     }
 }
 

--- a/frost-core/src/lib.rs
+++ b/frost-core/src/lib.rs
@@ -1,4 +1,6 @@
 #![allow(non_snake_case)]
+// It's emitting false positives; see https://github.com/rust-lang/rust-clippy/issues/9413
+#![allow(clippy::derive_partial_eq_without_eq)]
 #![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
 #![forbid(unsafe_code)]

--- a/frost-core/src/lib.rs
+++ b/frost-core/src/lib.rs
@@ -194,9 +194,9 @@ pub trait Ciphersuite: Copy + Clone {
 
     /// Verify a signature for this ciphersuite. The default implementation uses the "cofactored"
     /// equation (it multiplies by the cofactor returned by [`Group::cofactor()`]).
-    /// You may override this to provide a tailored implementation, but it must also multiply
-    /// by the cofactor to comply with the RFC.
-    fn VerifySignature(
+    /// You may override this to provide a tailored implementation, but if the ciphersuite defines it,
+    /// it must also multiply by the cofactor to comply with the RFC.
+    fn verify_signature(
         msg: &[u8],
         signature: &Signature<Self>,
         public_key: &VerifyingKey<Self>,

--- a/frost-core/src/lib.rs
+++ b/frost-core/src/lib.rs
@@ -194,8 +194,13 @@ pub trait Ciphersuite: Copy + Clone {
 
     /// Verify a signature for this ciphersuite. The default implementation uses the "cofactored"
     /// equation (it multiplies by the cofactor returned by [`Group::cofactor()`]).
+    ///
+    /// # Cryptographic Safety
+    ///
     /// You may override this to provide a tailored implementation, but if the ciphersuite defines it,
-    /// it must also multiply by the cofactor to comply with the RFC.
+    /// it must also multiply by the cofactor to comply with the RFC. Note that batch verification
+    /// (see [`crate::batch::Verifier`]) also uses the default implementation regardless whether a
+    /// tailored implementation was provided.
     fn verify_signature(
         msg: &[u8],
         signature: &Signature<Self>,

--- a/frost-core/src/verifying_key.rs
+++ b/frost-core/src/verifying_key.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Debug};
 
 use hex::FromHex;
 
-use crate::{Challenge, Ciphersuite, Error, Group, Signature};
+use crate::{Ciphersuite, Error, Group, Signature};
 
 /// A valid verifying key for Schnorr signatures over a FROST [`Ciphersuite::Group`].
 #[derive(Copy, Clone, PartialEq)]

--- a/frost-core/src/verifying_key.rs
+++ b/frost-core/src/verifying_key.rs
@@ -35,31 +35,7 @@ where
 
     /// Verify a purported `signature` over `msg` made by this verification key.
     pub fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<(), Error> {
-        let c = crate::challenge::<C>(&signature.R, &self.element, msg);
-
-        self.verify_prehashed(signature, c)
-    }
-
-    /// Verify a purported `signature` with a pre-hashed [`Challenge`] made by this verification
-    /// key.
-    pub(crate) fn verify_prehashed(
-        &self,
-        signature: &Signature<C>,
-        challenge: Challenge<C>,
-    ) -> Result<(), Error> {
-        // Verify check is h * ( - z * B + R  + c * A) == 0
-        //                 h * ( z * B - c * A - R) == 0
-        //
-        // where h is the cofactor
-        let zB = C::Group::generator() * signature.z;
-        let cA = self.element * challenge.0;
-        let check = (zB - cA - signature.R) * C::Group::cofactor();
-
-        if check == C::Group::identity() {
-            Ok(())
-        } else {
-            Err(Error::InvalidSignature)
-        }
+        C::VerifySignature(msg, signature, self)
     }
 }
 

--- a/frost-core/src/verifying_key.rs
+++ b/frost-core/src/verifying_key.rs
@@ -35,7 +35,7 @@ where
 
     /// Verify a purported `signature` over `msg` made by this verification key.
     pub fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<(), Error> {
-        C::VerifySignature(msg, signature, self)
+        C::verify_signature(msg, signature, self)
     }
 }
 


### PR DESCRIPTION
Based on #96 

Closes #91 

As it stands, the RFC can be interpreted as basically requiring cofactored verification (the cofactor curves require it, and the curves without cofactor don't, so we can always just multiply by the factor even if it's 1 and it will cover both cases). Thus the current implementation already follows the RFC. But in case there is the need to override it, this PR:

- Adds `VerifySignature` method to the `Ciphersuite` trait, with a default implementation with cofactored verification
- Changes the existing `VerifyingKey.verify()` to call that

There are many possible designs here, this is just what seemed to make more sense. We could also:

- Do nothing
- Don't provide a default implementation, which would allow us to remove `Group::cofactor()` if we want, but then we'd need to add one to every ciphersuite