### PR TITLE
Derive verification share and group public key from commitments

### DIFF
--- a/frost-core/src/tests.rs
+++ b/frost-core/src/tests.rs
@@ -16,7 +16,7 @@ pub fn check_share_generation<C: Ciphersuite, R: RngCore + CryptoRng>(mut rng: R
     let secret_shares = frost::keys::generate_secret_shares(&secret, 5, 3, rng).unwrap();
 
     for secret_share in secret_shares.iter() {
-        assert_eq!(secret_share.verify(), Ok(()));
+        assert!(secret_share.verify().is_ok());
     }
 
     assert_eq!(


### PR DESCRIPTION
Based on #106 

Closes #47 

This changes `SharePackage` to not contain the group and participant public keys, and instead derives them from the commitments. This was already explictly done in `SecretShare.verify()` and I just changed it to return those values.
