### PR TITLE
reject identity in Group::deserialize

### DIFF
--- a/frost-core/src/error.rs
+++ b/frost-core/src/error.rs
@@ -30,4 +30,7 @@ pub enum Error {
     /// This scalar MUST NOT be zero.
     #[error("Invalid for this scalar to be zero.")]
     InvalidZeroScalar,
+    /// This element MUST NOT be the identity.
+    #[error("Invalid for this element to be the identity.")]
+    InvalidIdentityElement,
 }

--- a/frost-p256/tests/frost.rs
+++ b/frost-p256/tests/frost.rs
@@ -1,3 +1,4 @@
+use frost_core::{Ciphersuite, Group};
 use frost_p256::*;
 use rand::thread_rng;
 
@@ -24,4 +25,14 @@ fn check_bad_batch_verify() {
     let rng = thread_rng();
 
     frost_core::tests::batch::bad_batch_verify::<P256Sha256, _>(rng);
+}
+
+#[test]
+fn check_deserialize_identity() {
+    // The identity is actually encoded as a single byte; but the API does not
+    // allow us to change that. Try to send something similar.
+    let encoded_identity = [0u8; 33];
+
+    let r = <<P256Sha256 as Ciphersuite>::Group as Group>::deserialize(&encoded_identity);
+    assert_eq!(r, Err(Error::MalformedElement));
 }

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -101,7 +101,13 @@ impl Group for RistrettoGroup {
 
     fn deserialize(buf: &Self::Serialization) -> Result<Self::Element, Error> {
         match CompressedRistretto::from_slice(buf.as_ref()).decompress() {
-            Some(point) => Ok(point),
+            Some(point) => {
+                if point == Self::identity() {
+                    Err(Error::InvalidIdentityElement)
+                } else {
+                    Ok(point)
+                }
+            }
             None => Err(Error::MalformedElement),
         }
     }

--- a/frost-ristretto255/tests/frost.rs
+++ b/frost-ristretto255/tests/frost.rs
@@ -1,3 +1,5 @@
+use curve25519_dalek::{ristretto::RistrettoPoint, traits::Identity};
+use frost_core::{Ciphersuite, Group};
 use frost_ristretto255::*;
 use rand::thread_rng;
 
@@ -20,4 +22,12 @@ fn check_bad_batch_verify() {
     let rng = thread_rng();
 
     frost_core::tests::batch::bad_batch_verify::<Ristretto255Sha512, _>(rng);
+}
+
+#[test]
+fn check_deserialize_identity() {
+    let encoded_identity = RistrettoPoint::identity().compress().to_bytes();
+
+    let r = <<Ristretto255Sha512 as Ciphersuite>::Group as Group>::deserialize(&encoded_identity);
+    assert_eq!(r, Err(Error::InvalidIdentityElement));
 }


### PR DESCRIPTION
Closes #134

While doing this I wondered if we should do the same in `serialize`, this is being currently discussed in chat, and we can do that in another PR if we want to.