### PR TITLE
Fix batching for P-256

### DIFF
--- a/frost-p256/tests/frost.rs
+++ b/frost-p256/tests/frost.rs
@@ -16,18 +16,14 @@ fn check_sign_with_dkg() {
     frost_core::tests::check_sign_with_dkg::<P256Sha256, _>(rng);
 }
 
-// TODO: re-enable after batch is changed to work with big-endian scalars
-// #[test]
-#[allow(unused)]
+#[test]
 fn check_batch_verify() {
     let rng = thread_rng();
 
     frost_core::tests::batch::batch_verify::<P256Sha256, _>(rng);
 }
 
-// TODO: re-enable after batch is changed to work with big-endian scalars
-// #[test]
-#[allow(unused)]
+#[test]
 fn check_bad_batch_verify() {
     let rng = thread_rng();
 


### PR DESCRIPTION
Depends on #114 

Uses the `little_endian_encoding` introduced in #114 to fix the bug described in #141.
Additionally, fixs another bug that would cause batching to fail for P-256, which was caused by the NAF size being fixed to 256. Since it's at most one element larger than the bit length, it worked for Ristretto (255) but not for P-256. I just increased it to 257.

Closes https://github.com/ZcashFoundation/frost/issues/141