### PR TITLE
use Error everywhere and add enums as needed

### DIFF
--- a/frost-core/src/error.rs
+++ b/frost-core/src/error.rs
@@ -6,6 +6,15 @@ use thiserror::Error;
 #[non_exhaustive]
 #[derive(Error, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Error {
+    /// min_signers it invalid
+    #[error("min_signers must be at least 2 and not larger than max_signers")]
+    InvalidMinSigners,
+    /// max_signers it invalid
+    #[error("max_signers must be at least 2")]
+    InvalidMaxSigners,
+    /// max_signers it invalid
+    #[error("coefficients must have min_signers-1 elements")]
+    InvalidCoefficients,
     /// This identifier is unserializable.
     #[error("Malformed identifier is unserializable.")]
     MalformedIdentifier,
@@ -36,4 +45,31 @@ pub enum Error {
     /// This element MUST have (large) prime order.
     #[error("Invalid for this element to not have large prime order.")]
     InvalidNonPrimeOrderElement,
+    /// Duplicated shares provided
+    #[error("Duplicated shares provided.")]
+    DuplicatedShares,
+    /// Commitment equals the identity
+    #[error("Commitment equals the identity.")]
+    IdentityCommitment,
+    /// Signature share verification failed.
+    #[error("Invalid signature share.")]
+    InvalidSignatureShare,
+    /// Secret share verification failed.
+    #[error("Invalid secret share.")]
+    InvalidSecretShare,
+    /// Round 1 package not found for Round 2 participant.
+    #[error("Round 1 package not found for Round 2 participant.")]
+    PackageNotFound,
+    /// Incorrect number of packages.
+    #[error("Incorrect number of packages.")]
+    IncorrectNumberOfPackages,
+    /// The incorrect package was specified.
+    #[error("The incorrect package was specified.")]
+    IncorrectPackage,
+    /// The ciphersuite does not support DKG.
+    #[error("The ciphersuite does not support DKG.")]
+    DKGNotSupported,
+    /// The proof of knowledge is not valid.
+    #[error("The proof of knowledge is not valid.")]
+    InvalidProofOfKnowledge,
 }

--- a/frost-core/src/error.rs
+++ b/frost-core/src/error.rs
@@ -6,13 +6,13 @@ use thiserror::Error;
 #[non_exhaustive]
 #[derive(Error, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Error {
-    /// min_signers it invalid
+    /// min_signers is invalid
     #[error("min_signers must be at least 2 and not larger than max_signers")]
     InvalidMinSigners,
-    /// max_signers it invalid
+    /// max_signers is invalid
     #[error("max_signers must be at least 2")]
     InvalidMaxSigners,
-    /// max_signers it invalid
+    /// max_signers is invalid
     #[error("coefficients must have min_signers-1 elements")]
     InvalidCoefficients,
     /// This identifier is unserializable.

--- a/frost-core/src/frost/keys/dkg.rs
+++ b/frost-core/src/frost/keys/dkg.rs
@@ -243,8 +243,7 @@ fn compute_verifying_keys<C: Ciphersuite>(
             // Chain our own commitment vector
             .chain(iter::once(Ok(&round2_secret_package.commitment)))
         {
-            let result = evaluate_vss(commitments?, i);
-            y_i = y_i + result;
+            y_i = y_i + evaluate_vss(commitments?, i);
         }
         let y_i = VerifyingShare(y_i);
         others_verifying_keys.insert(i, y_i);

--- a/frost-core/src/frost/round1.rs
+++ b/frost-core/src/frost/round1.rs
@@ -76,6 +76,7 @@ where
 //     }
 // }
 
+#[cfg(any(test, feature = "test-impl"))]
 impl<C> FromHex for Nonce<C>
 where
     C: Ciphersuite,
@@ -139,6 +140,7 @@ where
     }
 }
 
+#[cfg(any(test, feature = "test-impl"))]
 impl<C> FromHex for NonceCommitment<C>
 where
     C: Ciphersuite,

--- a/frost-core/src/frost/round2.rs
+++ b/frost-core/src/frost/round2.rs
@@ -86,11 +86,11 @@ where
         public_key: &frost::keys::VerifyingShare<C>,
         lambda_i: Scalar<C>,
         challenge: &Challenge<C>,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), Error> {
         if (<C::Group>::generator() * self.signature.z_share)
             != (group_commitment_share.0 + (public_key.0 * challenge.0 * lambda_i))
         {
-            return Err("Invalid signature share");
+            return Err(Error::InvalidSignatureShare);
         }
 
         Ok(())
@@ -131,7 +131,7 @@ pub fn sign<C: Ciphersuite>(
     signing_package: &SigningPackage<C>,
     signer_nonces: &round1::SigningNonces<C>,
     key_package: &frost::keys::KeyPackage<C>,
-) -> Result<SignatureShare<C>, &'static str> {
+) -> Result<SignatureShare<C>, Error> {
     // Encodes the signing commitment list produced in round one as part of generating [`BindingFactor`], the
     // binding factor.
     let binding_factor_list: frost::BindingFactorList<C> = signing_package.into();

--- a/frost-core/src/verifying_key.rs
+++ b/frost-core/src/verifying_key.rs
@@ -72,6 +72,7 @@ where
     }
 }
 
+#[cfg(any(test, feature = "test-impl"))]
 impl<C> FromHex for VerifyingKey<C>
 where
     C: Ciphersuite,

--- a/frost-ed25519/src/lib.rs
+++ b/frost-ed25519/src/lib.rs
@@ -175,7 +175,7 @@ pub mod keys {
         max_signers: u16,
         min_signers: u16,
         mut rng: RNG,
-    ) -> Result<(Vec<SecretShare>, PublicKeyPackage), &'static str> {
+    ) -> Result<(Vec<SecretShare>, PublicKeyPackage), Error> {
         frost::keys::keygen_with_dealer(max_signers, min_signers, &mut rng)
     }
 
@@ -266,7 +266,7 @@ pub mod round2 {
         signing_package: &SigningPackage,
         signer_nonces: &round1::SigningNonces,
         key_package: &keys::KeyPackage,
-    ) -> Result<SignatureShare, &'static str> {
+    ) -> Result<SignatureShare, Error> {
         frost::round2::sign(signing_package, signer_nonces, key_package)
     }
 }
@@ -293,7 +293,7 @@ pub fn aggregate(
     signing_package: &round2::SigningPackage,
     signature_shares: &[round2::SignatureShare],
     pubkeys: &keys::PublicKeyPackage,
-) -> Result<Signature, &'static str> {
+) -> Result<Signature, Error> {
     frost::aggregate(signing_package, signature_shares, pubkeys)
 }
 

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -253,7 +253,7 @@ pub mod keys {
         max_signers: u16,
         min_signers: u16,
         mut rng: RNG,
-    ) -> Result<(Vec<SecretShare>, PublicKeyPackage), &'static str> {
+    ) -> Result<(Vec<SecretShare>, PublicKeyPackage), Error> {
         frost::keys::keygen_with_dealer(max_signers, min_signers, &mut rng)
     }
 
@@ -343,7 +343,7 @@ pub mod round2 {
         signing_package: &SigningPackage,
         signer_nonces: &round1::SigningNonces,
         key_package: &keys::KeyPackage,
-    ) -> Result<SignatureShare, &'static str> {
+    ) -> Result<SignatureShare, Error> {
         frost::round2::sign(signing_package, signer_nonces, key_package)
     }
 }
@@ -370,7 +370,7 @@ pub fn aggregate(
     signing_package: &round2::SigningPackage,
     signature_shares: &[round2::SignatureShare],
     pubkeys: &keys::PublicKeyPackage,
-) -> Result<Signature, &'static str> {
+) -> Result<Signature, Error> {
     frost::aggregate(signing_package, signature_shares, pubkeys)
 }
 

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -231,7 +231,7 @@ pub mod keys {
         max_signers: u16,
         min_signers: u16,
         mut rng: RNG,
-    ) -> Result<(Vec<SecretShare>, PublicKeyPackage), &'static str> {
+    ) -> Result<(Vec<SecretShare>, PublicKeyPackage), Error> {
         frost::keys::keygen_with_dealer(max_signers, min_signers, &mut rng)
     }
 
@@ -322,7 +322,7 @@ pub mod round2 {
         signing_package: &SigningPackage,
         signer_nonces: &round1::SigningNonces,
         key_package: &keys::KeyPackage,
-    ) -> Result<SignatureShare, &'static str> {
+    ) -> Result<SignatureShare, Error> {
         frost::round2::sign(signing_package, signer_nonces, key_package)
     }
 }
@@ -349,7 +349,7 @@ pub fn aggregate(
     signing_package: &round2::SigningPackage,
     signature_shares: &[round2::SignatureShare],
     pubkeys: &keys::PublicKeyPackage,
-) -> Result<Signature, &'static str> {
+) -> Result<Signature, Error> {
     frost::aggregate(signing_package, signature_shares, pubkeys)
 }
 


### PR DESCRIPTION
Closes #167 

I decided to keep everything into a single enum to see how many items would it have.

It's a bit big but I'm not sure if it warrants having different enums for different parts. What do you think?

Also I put the `FromHex` impls behind the test flag since it's only used in tests, and did not create a specific error for them. Also not sure what is the best approach here.
