### PR TITLE
remove random_nonzero from Field trait

### DIFF
--- a/frost-core/src/frost/keys.rs
+++ b/frost-core/src/frost/keys.rs
@@ -12,7 +12,10 @@ use hex::FromHex;
 use rand_core::{CryptoRng, RngCore};
 use zeroize::{DefaultIsZeroes, Zeroize};
 
-use crate::{frost::Identifier, Ciphersuite, Element, Error, Field, Group, Scalar, VerifyingKey};
+use crate::{
+    frost::Identifier, random_nonzero, Ciphersuite, Element, Error, Field, Group, Scalar,
+    VerifyingKey,
+};
 
 pub mod dkg;
 
@@ -56,7 +59,7 @@ where
     where
         R: CryptoRng + RngCore,
     {
-        Self(<<C::Group as Group>::Field>::random_nonzero(&mut rng))
+        Self(random_nonzero::<C, R>(&mut rng))
     }
 }
 

--- a/frost-core/src/signing_key.rs
+++ b/frost-core/src/signing_key.rs
@@ -2,7 +2,7 @@
 
 use rand_core::{CryptoRng, RngCore};
 
-use crate::{Ciphersuite, Error, Field, Group, Scalar, Signature, VerifyingKey};
+use crate::{random_nonzero, Ciphersuite, Error, Field, Group, Scalar, Signature, VerifyingKey};
 
 /// A signing key for a Schnorr signature on a FROST [`Ciphersuite::Group`].
 #[derive(Copy, Clone)]
@@ -19,7 +19,7 @@ where
 {
     /// Generate a new signing key.
     pub fn new<R: RngCore + CryptoRng>(mut rng: R) -> SigningKey<C> {
-        let scalar = <<C::Group as Group>::Field>::random_nonzero(&mut rng);
+        let scalar = random_nonzero::<C, R>(&mut rng);
 
         SigningKey { scalar }
     }
@@ -39,7 +39,7 @@ where
 
     /// Create a signature `msg` using this `SigningKey`.
     pub fn sign<R: RngCore + CryptoRng>(&self, mut rng: R, msg: &[u8]) -> Signature<C> {
-        let k = <<C::Group as Group>::Field>::random_nonzero(&mut rng);
+        let k = random_nonzero::<C, R>(&mut rng);
 
         let R = <C::Group>::generator() * k;
 

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -52,17 +52,6 @@ impl Field for P256ScalarField {
         Scalar::random(rng)
     }
 
-    fn random_nonzero<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
-        loop {
-            let scalar = Scalar::random(&mut *rng);
-
-            // This impl of `Eq` calls to `ConstantTimeEq` under the hood
-            if scalar != Scalar::zero() {
-                return scalar;
-            }
-        }
-    }
-
     fn serialize(scalar: &Self::Scalar) -> Self::Serialization {
         scalar.to_bytes().into()
     }

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -49,17 +49,6 @@ impl Field for RistrettoScalarField {
         Scalar::random(rng)
     }
 
-    fn random_nonzero<R: RngCore + CryptoRng>(rng: &mut R) -> Self::Scalar {
-        loop {
-            let scalar = Scalar::random(rng);
-
-            // This impl of `Eq` calls to `ConstantTimeEq` under the hood
-            if scalar != Scalar::zero() {
-                return scalar;
-            }
-        }
-    }
-
     fn serialize(scalar: &Self::Scalar) -> Self::Serialization {
         scalar.to_bytes()
     }


### PR DESCRIPTION
This is a optional cleanup.

Upside: removes a trait method
Downside: implementers must guarantee that PartialEq/Eq for scalars are constant time.

If that does not look like a good idea, we can change this PR to simply call the global `random_nonzero` function in each ciphersuite just to avoid duplicated code, making it possible for other ciphersuites to provide their own implementation if needed.