### PR TITLE
add signer identifier to InvalidSignatureShare as a byte array

### DIFF
--- a/frost-core/src/error.rs
+++ b/frost-core/src/error.rs
@@ -55,8 +55,9 @@ pub enum Error {
     #[error("Invalid signature share.")]
     InvalidSignatureShare {
         /// The identifier of the signer whose share validation failed,
-        /// encoded as a little-endian byte string in hex format.
-        signer: String,
+        /// encoded as a byte vector with ciphersuite-dependent endianness
+        /// (can be decoded with [`Identifier::deserialize`]).
+        signer: Vec<u8>,
     },
     /// Secret share verification failed.
     #[error("Invalid secret share.")]

--- a/frost-core/src/error.rs
+++ b/frost-core/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 /// An error related to FROST.
 #[non_exhaustive]
-#[derive(Error, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Error, Debug, Clone, Eq, PartialEq)]
 pub enum Error {
     /// min_signers is invalid
     #[error("min_signers must be at least 2 and not larger than max_signers")]
@@ -53,7 +53,11 @@ pub enum Error {
     IdentityCommitment,
     /// Signature share verification failed.
     #[error("Invalid signature share.")]
-    InvalidSignatureShare,
+    InvalidSignatureShare {
+        /// The identifier of the signer whose share validation failed,
+        /// encoded as a little-endian byte string in hex format.
+        signer: String,
+    },
     /// Secret share verification failed.
     #[error("Invalid secret share.")]
     InvalidSecretShare,

--- a/frost-core/src/error.rs
+++ b/frost-core/src/error.rs
@@ -56,7 +56,7 @@ pub enum Error {
     InvalidSignatureShare {
         /// The identifier of the signer whose share validation failed,
         /// encoded as a byte vector with ciphersuite-dependent endianness
-        /// (can be decoded with [`Identifier::deserialize`]).
+        /// (can be decoded with [`crate::frost::Identifier::deserialize`]).
         signer: Vec<u8>,
     },
     /// Secret share verification failed.

--- a/frost-core/src/frost/identifier.rs
+++ b/frost-core/src/frost/identifier.rs
@@ -19,9 +19,22 @@ impl<C> Identifier<C>
 where
     C: Ciphersuite,
 {
-    // Serialize the underlying scalar.
-    pub(crate) fn serialize(&self) -> <<C::Group as Group>::Field as Field>::Serialization {
+    /// Serialize the identifier using the ciphersuite encoding.
+    pub fn serialize(&self) -> <<C::Group as Group>::Field as Field>::Serialization {
         <<C::Group as Group>::Field>::serialize(&self.0)
+    }
+
+    /// Deserialize an Identifier from a serialized buffer.
+    /// Returns an error if it attempts to deserialize zero.
+    pub fn deserialize(
+        buf: &<<C::Group as Group>::Field as Field>::Serialization,
+    ) -> Result<Self, Error> {
+        let scalar = <<C::Group as Group>::Field>::deserialize(buf)?;
+        if scalar == <<C::Group as Group>::Field>::zero() {
+            Err(Error::InvalidZeroScalar)
+        } else {
+            Ok(Self(scalar))
+        }
     }
 }
 

--- a/frost-core/src/frost/identifier.rs
+++ b/frost-core/src/frost/identifier.rs
@@ -1,7 +1,7 @@
 //! FROST participant identifiers
 
 use std::{
-    fmt::{self, Debug},
+    fmt::{self, Debug, Display},
     hash::{Hash, Hasher},
 };
 
@@ -22,6 +22,23 @@ where
     // Serialize the underlying scalar.
     pub(crate) fn serialize(&self) -> <<C::Group as Group>::Field as Field>::Serialization {
         <<C::Group as Group>::Field>::serialize(&self.0)
+    }
+}
+
+impl<C> Display for Identifier<C>
+where
+    C: Ciphersuite,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            hex::encode(
+                <<<C as Ciphersuite>::Group as Group>::Field as Field>::little_endian_serialize(
+                    &self.0
+                )
+            )
+        )
     }
 }
 

--- a/frost-core/src/frost/round2.rs
+++ b/frost-core/src/frost/round2.rs
@@ -91,7 +91,7 @@ where
             != (group_commitment_share.0 + (public_key.0 * challenge.0 * lambda_i))
         {
             return Err(Error::InvalidSignatureShare {
-                signer: self.identifier.to_string(),
+                signer: self.identifier.serialize().as_ref().to_vec(),
             });
         }
 

--- a/frost-core/src/frost/round2.rs
+++ b/frost-core/src/frost/round2.rs
@@ -90,7 +90,9 @@ where
         if (<C::Group>::generator() * self.signature.z_share)
             != (group_commitment_share.0 + (public_key.0 * challenge.0 * lambda_i))
         {
-            return Err(Error::InvalidSignatureShare);
+            return Err(Error::InvalidSignatureShare {
+                signer: self.identifier.to_string(),
+            });
         }
 
         Ok(())

--- a/frost-core/src/tests.rs
+++ b/frost-core/src/tests.rs
@@ -70,14 +70,17 @@ fn check_corrupted_share<C: Ciphersuite + PartialEq, R: RngCore + CryptoRng>(
     let identifier_one = 1u16.try_into().expect("should be nonzero");
     let mut corrupted_signature_shares = signature_shares.to_owned();
     let random_share = <<C::Group as Group>::Field>::random(&mut rng);
+
     corrupted_signature_shares
         .iter_mut()
         .find(|share| share.identifier == identifier_one)
         .unwrap()
         .signature
         .z_share = random_share;
+
     let group_signature_res =
         frost::aggregate(signing_package, &corrupted_signature_shares[..], pubkeys);
+
     match group_signature_res {
         Ok(_) => panic!("should fail"),
         Err(Error::InvalidSignatureShare { signer }) => {

--- a/frost-core/src/tests.rs
+++ b/frost-core/src/tests.rs
@@ -1,7 +1,11 @@
 //! Ciphersuite-generic test functions.
 use std::{collections::HashMap, convert::TryFrom};
 
-use crate::{frost, Error, Field, Group};
+use crate::{
+    frost::{self, Identifier},
+    Error, Field, Group,
+};
+use debugless_unwrap::DebuglessUnwrap;
 use rand_core::{CryptoRng, RngCore};
 
 use crate::Ciphersuite;
@@ -84,9 +88,9 @@ fn check_corrupted_share<C: Ciphersuite + PartialEq, R: RngCore + CryptoRng>(
     match group_signature_res {
         Ok(_) => panic!("should fail"),
         Err(Error::InvalidSignatureShare { signer }) => {
-            // starts_with is used instead of equality so that this works even with larger scalar fields
-            assert!(signer
-                .starts_with("0100000000000000000000000000000000000000000000000000000000000000"));
+            let decoded_identifier =
+                Identifier::deserialize(&signer.try_into().debugless_unwrap()).unwrap();
+            assert_eq!(identifier_one, decoded_identifier);
         }
         Err(_) => panic!("should fail with InvalidSignatureShare"),
     }


### PR DESCRIPTION
One feature of FROST is that cheaters can be detected which allows removing/blocking them if desired.

However, currently, there is now way to identify which participant caused the signature aggregation to fail.

This adds the signer identifier to the InvalidSignatureShare error, which allows this.

Ideally we'd add a `Identifier` instead of a hex string. But since identifier is generic on the ciphersuite, that would require making the Error enum also generic, but that doesn't work on the Field trait (which has two methods that return Error) since it isn't aware of the ciphersuite it's in.

We could e.g. split the error enum, but this is the simplest approach. I went ahead and created the PR since it makes a bit clearer to think about the problem, but I'd be happy to use another approach if preferred. **Edit: I did the alternate approach in https://github.com/ZcashFoundation/frost/pull/183**

There is not matching issue for this, I can create it if required.