### PR TITLE
add bound to ConstantTimeEq in Scalar

### DIFF
--- a/frost-core/Cargo.toml
+++ b/frost-core/Cargo.toml
@@ -23,6 +23,7 @@ digest = "0.10"
 hex = { version = "0.4.3", features = ["serde"] }
 rand_core = "0.6"
 serde = { version = "1", optional = true, features = ["derive"] }
+subtle = "2.4.1"
 thiserror = "1.0"
 zeroize = { version = "1.5.4", default-features = false, features = ["derive"] }
 

--- a/frost-ed448/src/lib.rs
+++ b/frost-ed448/src/lib.rs
@@ -12,7 +12,7 @@ use sha3::{
     Shake256,
 };
 
-use frost_core::{frost, Ciphersuite, Field, Group};
+use frost_core::{frost, Ciphersuite, ConstantTimeEq, Field, Group};
 
 #[cfg(test)]
 mod tests;
@@ -37,7 +37,7 @@ impl Field for Ed448ScalarField {
     }
 
     fn invert(scalar: &Self::Scalar) -> Result<Self::Scalar, Error> {
-        if *scalar == <Self as Field>::zero() {
+        if scalar.ct_eq(&<Self as Field>::zero()).into() {
             Err(Error::InvalidZeroScalar)
         } else {
             Ok(scalar.invert())

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -14,7 +14,7 @@ use p256::{
 use rand_core::{CryptoRng, RngCore};
 use sha2::{digest::Update, Digest, Sha256};
 
-use frost_core::{frost, Ciphersuite, Field, Group};
+use frost_core::{frost, Ciphersuite, ConstantTimeEq, Field, Group};
 
 #[cfg(test)]
 mod tests;
@@ -39,9 +39,7 @@ impl Field for P256ScalarField {
     }
 
     fn invert(scalar: &Self::Scalar) -> Result<Self::Scalar, Error> {
-        // [`p256::Scalar`]'s Eq/PartialEq does a constant-time comparison using
-        // `ConstantTimeEq`
-        if *scalar == <Self as Field>::zero() {
+        if scalar.ct_eq(&<Self as Field>::zero()).into() {
             Err(Error::InvalidZeroScalar)
         } else {
             Ok(scalar.invert().unwrap())

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -11,7 +11,7 @@ use curve25519_dalek::{
 use rand_core::{CryptoRng, RngCore};
 use sha2::{digest::Update, Digest, Sha512};
 
-use frost_core::{frost, Ciphersuite, Field, Group};
+use frost_core::{frost, Ciphersuite, ConstantTimeEq, Field, Group};
 
 #[cfg(test)]
 mod tests;
@@ -36,9 +36,7 @@ impl Field for RistrettoScalarField {
     }
 
     fn invert(scalar: &Self::Scalar) -> Result<Self::Scalar, Error> {
-        // [`curve25519_dalek::scalar::Scalar`]'s Eq/PartialEq does a constant-time comparison using
-        // `ConstantTimeEq`
-        if *scalar == <Self as Field>::zero() {
+        if scalar.ct_eq(&<Self as Field>::zero()).into() {
             Err(Error::InvalidZeroScalar)
         } else {
             Ok(scalar.invert())

--- a/frost-secp256k1/src/lib.rs
+++ b/frost-secp256k1/src/lib.rs
@@ -16,7 +16,7 @@ use k256::{
 use rand_core::{CryptoRng, RngCore};
 use sha2::{digest::Update, Digest, Sha256};
 
-use frost_core::{frost, Ciphersuite, Field, Group};
+use frost_core::{frost, Ciphersuite, ConstantTimeEq, Field, Group};
 
 #[cfg(test)]
 mod tests;
@@ -41,8 +41,7 @@ impl Field for Secp256K1ScalarField {
     }
 
     fn invert(scalar: &Self::Scalar) -> Result<Self::Scalar, Error> {
-        // [`Scalar`]'s Eq/PartialEq does a constant-time comparison
-        if *scalar == <Self as Field>::zero() {
+        if scalar.ct_eq(&<Self as Field>::zero()).into() {
             Err(Error::InvalidZeroScalar)
         } else {
             Ok(scalar.invert().unwrap())


### PR DESCRIPTION
Not sure if we want this or not, but this allows us to use `ct_eq` where needed instead of just documenting that `eq` should be constant time.

(Ideally we could remove `Eq` to make sure we're using `ct_eq` where needed but this propagates everywhere and doesn't seem worth it)