### PR TITLE
docs cleanups

### DIFF
--- a/frost-core/src/frost.rs
+++ b/frost-core/src/frost.rs
@@ -363,7 +363,7 @@ where
     //
     // Implements [`aggregate`] from the spec.
     //
-    // [`aggregate`]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#section-5.3
+    // [`aggregate`]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-5.3
     let mut z = <<C::Group as Group>::Field>::zero();
 
     for signature_share in signature_shares {

--- a/frost-core/src/frost/keys.rs
+++ b/frost-core/src/frost/keys.rs
@@ -346,7 +346,7 @@ pub fn keygen_with_dealer<C: Ciphersuite, R: RngCore + CryptoRng>(
 ///
 /// Implements [`polynomial_evaluate`] from the spec.
 ///
-/// [`polynomial_evaluate`]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#name-evaluation-of-a-polynomial
+/// [`polynomial_evaluate`]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#name-evaluation-of-a-polynomial
 fn evaluate_polynomial<C: Ciphersuite>(
     identifier: Identifier<C>,
     coefficients: &[Scalar<C>],

--- a/frost-core/src/lib.rs
+++ b/frost-core/src/lib.rs
@@ -119,8 +119,6 @@ pub trait Group: Copy + Clone + PartialEq {
     /// full curve group.
     ///
     /// If using a prime order elliptic curve, the cofactor should be 1 in the scalar field.
-    ///
-    /// <https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-04.html#section-4.1-3>
     fn cofactor() -> <Self::Field as Field>::Scalar;
 
     /// Additive [identity] of the prime order group.
@@ -171,21 +169,21 @@ pub trait Ciphersuite: Copy + Clone + PartialEq {
 
     /// [H1] for a FROST ciphersuite.
     ///
-    /// Maps arbitrary inputs to non-zero `Self::Scalar` elements of the prime-order group scalar field.
+    /// Maps arbitrary inputs to `Self::Scalar` elements of the prime-order group scalar field.
     ///
     /// [H1]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#name-cryptographic-hash-function
     fn H1(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar;
 
     /// [H2] for a FROST ciphersuite.
     ///
-    /// Maps arbitrary inputs to non-zero `Self::Scalar` elements of the prime-order group scalar field.
+    /// Maps arbitrary inputs to `Self::Scalar` elements of the prime-order group scalar field.
     ///
     /// [H2]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#name-cryptographic-hash-function
     fn H2(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar;
 
     /// [H3] for a FROST ciphersuite.
     ///
-    /// Maps arbitrary inputs to non-zero `Self::Scalar` elements of the prime-order group scalar field.
+    /// Maps arbitrary inputs to `Self::Scalar` elements of the prime-order group scalar field.
     ///
     /// [H3]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#name-cryptographic-hash-function
     fn H3(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar;
@@ -261,8 +259,8 @@ where
 ///
 /// This is the only invocation of the H2 hash function from the [RFC].
 ///
-/// [FROST]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#name-signature-challenge-computa
-/// [RFC]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#section-3.2
+/// [FROST]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#name-signature-challenge-computa
+/// [RFC]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-3.2
 fn challenge<C>(R: &Element<C>, verifying_key: &Element<C>, msg: &[u8]) -> Challenge<C>
 where
     C: Ciphersuite,

--- a/frost-ed25519/src/lib.rs
+++ b/frost-ed25519/src/lib.rs
@@ -66,7 +66,7 @@ impl Group for Ed25519Group {
 
 /// Context string 'FROST-RISTRETTO255-SHA512-v5' from the ciphersuite in the [spec]
 ///
-/// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#section-6.1-1
+/// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.1-1
 const CONTEXT_STRING: &str = "FROST-ED25519-SHA512-v11";
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -82,7 +82,7 @@ impl Ciphersuite for Ed25519Sha512 {
 
     /// H1 for FROST(Ed25519, SHA-512)
     ///
-    /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#section-6.1-2.2.2.1
+    /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.1-2.2.2.1
     fn H1(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
         let h = Sha512::new()
             .chain(CONTEXT_STRING.as_bytes())
@@ -96,7 +96,7 @@ impl Ciphersuite for Ed25519Sha512 {
 
     /// H2 for FROST(Ed25519, SHA-512)
     ///
-    /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#section-6.1-2.2.2.2
+    /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.1-2.2.2.2
     fn H2(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
         let h = Sha512::new().chain(m);
 
@@ -107,7 +107,7 @@ impl Ciphersuite for Ed25519Sha512 {
 
     /// H3 for FROST(Ed25519, SHA-512)
     ///
-    /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#section-6.1-2.2.2.3
+    /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.1-2.2.2.3
     fn H3(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
         let h = Sha512::new()
             .chain(CONTEXT_STRING.as_bytes())
@@ -121,7 +121,7 @@ impl Ciphersuite for Ed25519Sha512 {
 
     /// H4 for FROST(Ed25519, SHA-512)
     ///
-    /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#section-6.1-2.2.2.4
+    /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.1-2.2.2.4
     fn H4(m: &[u8]) -> Self::HashOutput {
         let h = Sha512::new()
             .chain(CONTEXT_STRING.as_bytes())
@@ -135,7 +135,7 @@ impl Ciphersuite for Ed25519Sha512 {
 
     /// H5 for FROST(Ed25519, SHA-512)
     ///
-    /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#section-6.1-2.2.2.5
+    /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.1-2.2.2.5
     fn H5(m: &[u8]) -> Self::HashOutput {
         let h = Sha512::new()
             .chain(CONTEXT_STRING.as_bytes())


### PR DESCRIPTION
- Bump `-10` links to `-11`
- Remove mention to `non-zero` in hash functions - this is not enforced anymore in the spec (and they return zero with negligible probability anyway)
- Remove stale link in `cofactor()` which is not in the spec anymore but it's still being used