### PR TITLE
refactor hash implementations with hash_to_array/scalar functions

### DIFF
--- a/frost-ed25519/src/lib.rs
+++ b/frost-ed25519/src/lib.rs
@@ -9,7 +9,7 @@ use curve25519_dalek::{
     traits::Identity,
 };
 use rand_core::{CryptoRng, RngCore};
-use sha2::{digest::Update, Digest, Sha512};
+use sha2::{Digest, Sha512};
 
 use frost_core::{frost, Ciphersuite, Field, Group};
 
@@ -64,6 +64,21 @@ impl Group for Ed25519Group {
     }
 }
 
+fn hash_to_array(inputs: &[&[u8]]) -> [u8; 64] {
+    let mut h = Sha512::new();
+    for i in inputs {
+        h.update(i);
+    }
+    let mut output = [0u8; 64];
+    output.copy_from_slice(h.finalize().as_slice());
+    output
+}
+
+fn hash_to_scalar(inputs: &[&[u8]]) -> Scalar {
+    let output = hash_to_array(inputs);
+    Scalar::from_bytes_mod_order_wide(&output)
+}
+
 /// Context string 'FROST-RISTRETTO255-SHA512-v5' from the ciphersuite in the [spec]
 ///
 /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#section-6.1-1
@@ -84,79 +99,40 @@ impl Ciphersuite for Ed25519Sha512 {
     ///
     /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#section-6.1-2.2.2.1
     fn H1(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
-        let h = Sha512::new()
-            .chain(CONTEXT_STRING.as_bytes())
-            .chain("rho")
-            .chain(m);
-
-        let mut output = [0u8; 64];
-        output.copy_from_slice(h.finalize().as_slice());
-        <<Self::Group as Group>::Field as Field>::Scalar::from_bytes_mod_order_wide(&output)
+        hash_to_scalar(&[CONTEXT_STRING.as_bytes(), b"rho", m])
     }
 
     /// H2 for FROST(Ed25519, SHA-512)
     ///
     /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#section-6.1-2.2.2.2
     fn H2(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
-        let h = Sha512::new().chain(m);
-
-        let mut output = [0u8; 64];
-        output.copy_from_slice(h.finalize().as_slice());
-        <<Self::Group as Group>::Field as Field>::Scalar::from_bytes_mod_order_wide(&output)
+        hash_to_scalar(&[m])
     }
 
     /// H3 for FROST(Ed25519, SHA-512)
     ///
     /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#section-6.1-2.2.2.3
     fn H3(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
-        let h = Sha512::new()
-            .chain(CONTEXT_STRING.as_bytes())
-            .chain("nonce")
-            .chain(m);
-
-        let mut output = [0u8; 64];
-        output.copy_from_slice(h.finalize().as_slice());
-        <<Self::Group as Group>::Field as Field>::Scalar::from_bytes_mod_order_wide(&output)
+        hash_to_scalar(&[CONTEXT_STRING.as_bytes(), b"nonce", m])
     }
 
     /// H4 for FROST(Ed25519, SHA-512)
     ///
     /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#section-6.1-2.2.2.4
     fn H4(m: &[u8]) -> Self::HashOutput {
-        let h = Sha512::new()
-            .chain(CONTEXT_STRING.as_bytes())
-            .chain("msg")
-            .chain(m);
-
-        let mut output = [0u8; 64];
-        output.copy_from_slice(h.finalize().as_slice());
-        output
+        hash_to_array(&[CONTEXT_STRING.as_bytes(), b"msg", m])
     }
 
     /// H5 for FROST(Ed25519, SHA-512)
     ///
     /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-10.html#section-6.1-2.2.2.5
     fn H5(m: &[u8]) -> Self::HashOutput {
-        let h = Sha512::new()
-            .chain(CONTEXT_STRING.as_bytes())
-            .chain("com")
-            .chain(m);
-
-        let mut output = [0u8; 64];
-        output.copy_from_slice(h.finalize().as_slice());
-        output
+        hash_to_array(&[CONTEXT_STRING.as_bytes(), b"com", m])
     }
 
     /// HDKG for FROST(Ed25519, SHA-512)
     fn HDKG(m: &[u8]) -> Option<<<Self::Group as Group>::Field as Field>::Scalar> {
-        let h = Sha512::new()
-            .chain(CONTEXT_STRING.as_bytes())
-            .chain("dkg")
-            .chain(m);
-
-        let mut output = [0u8; 64];
-        output.copy_from_slice(h.finalize().as_slice());
-        Some(<<Self::Group as Group>::Field as Field>::Scalar::from_bytes_mod_order_wide(&output))
+        Some(hash_to_scalar(&[CONTEXT_STRING.as_bytes(), b"dkg", m]))
     }
 }
 

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -12,7 +12,7 @@ use p256::{
     AffinePoint, ProjectivePoint, Scalar,
 };
 use rand_core::{CryptoRng, RngCore};
-use sha2::{digest::Update, Digest, Sha256};
+use sha2::{Digest, Sha256};
 
 use frost_core::{frost, Ciphersuite, Field, Group};
 
@@ -139,6 +139,23 @@ impl Group for P256Group {
     }
 }
 
+fn hash_to_array(inputs: &[&[u8]]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    for i in inputs {
+        h.update(i);
+    }
+    let mut output = [0u8; 32];
+    output.copy_from_slice(h.finalize().as_slice());
+    output
+}
+
+fn hash_to_scalar(domain: &[u8], msg: &[u8]) -> Scalar {
+    let mut u = [P256ScalarField::zero()];
+    hash_to_field::<ExpandMsgXmd<Sha256>, Scalar>(&[msg], domain, &mut u)
+        .expect("should never return error according to error cases described in ExpandMsgXmd");
+    u[0]
+}
+
 /// Context string from the ciphersuite in the [spec]
 ///
 /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.4-1
@@ -159,70 +176,43 @@ impl Ciphersuite for P256Sha256 {
     ///
     /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.4-2.2.2.1
     fn H1(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
-        let mut u = [P256ScalarField::zero()];
-        let dst = CONTEXT_STRING.to_owned() + "rho";
-        hash_to_field::<ExpandMsgXmd<Sha256>, Scalar>(&[m], dst.as_bytes(), &mut u)
-            .expect("should never return error according to error cases described in ExpandMsgXmd");
-        u[0]
+        hash_to_scalar((CONTEXT_STRING.to_owned() + "rho").as_bytes(), m)
     }
 
     /// H2 for FROST(P-256, SHA-256)
     ///
     /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.4-2.2.2.2
     fn H2(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
-        let mut u = [P256ScalarField::zero()];
-        let dst = CONTEXT_STRING.to_owned() + "chal";
-        hash_to_field::<ExpandMsgXmd<Sha256>, Scalar>(&[m], dst.as_bytes(), &mut u)
-            .expect("should never return error according to error cases described in ExpandMsgXmd");
-        u[0]
+        hash_to_scalar((CONTEXT_STRING.to_owned() + "chal").as_bytes(), m)
     }
 
     /// H3 for FROST(P-256, SHA-256)
     ///
     /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.4-2.2.2.3
     fn H3(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
-        let mut u = [P256ScalarField::zero()];
-        let dst = CONTEXT_STRING.to_owned() + "nonce";
-        hash_to_field::<ExpandMsgXmd<Sha256>, Scalar>(&[m], dst.as_bytes(), &mut u)
-            .expect("should never return error according to error cases described in ExpandMsgXmd");
-        u[0]
+        hash_to_scalar((CONTEXT_STRING.to_owned() + "nonce").as_bytes(), m)
     }
 
     /// H4 for FROST(P-256, SHA-256)
     ///
     /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.4-2.2.2.4
     fn H4(m: &[u8]) -> Self::HashOutput {
-        let h = Sha256::new()
-            .chain(CONTEXT_STRING.as_bytes())
-            .chain("msg")
-            .chain(m);
-
-        let mut output = [0u8; 32];
-        output.copy_from_slice(h.finalize().as_slice());
-        output
+        hash_to_array(&[CONTEXT_STRING.as_bytes(), b"msg", m])
     }
 
     /// H5 for FROST(P-256, SHA-256)
     ///
     /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.4-2.2.2.5
     fn H5(m: &[u8]) -> Self::HashOutput {
-        let h = Sha256::new()
-            .chain(CONTEXT_STRING.as_bytes())
-            .chain("com")
-            .chain(m);
-
-        let mut output = [0u8; 32];
-        output.copy_from_slice(h.finalize().as_slice());
-        output
+        hash_to_array(&[CONTEXT_STRING.as_bytes(), b"com", m])
     }
 
     /// HDKG for FROST(P-256, SHA-256)
     fn HDKG(m: &[u8]) -> Option<<<Self::Group as Group>::Field as Field>::Scalar> {
-        let mut u = [P256ScalarField::zero()];
-        let dst = CONTEXT_STRING.to_owned() + "dkg";
-        hash_to_field::<ExpandMsgXmd<Sha256>, Scalar>(&[m], dst.as_bytes(), &mut u)
-            .expect("should never return error according to error cases described in ExpandMsgXmd");
-        Some(u[0])
+        Some(hash_to_scalar(
+            (CONTEXT_STRING.to_owned() + "dkg").as_bytes(),
+            m,
+        ))
     }
 }
 

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -9,7 +9,7 @@ use curve25519_dalek::{
     traits::Identity,
 };
 use rand_core::{CryptoRng, RngCore};
-use sha2::{digest::Update, Digest, Sha512};
+use sha2::{Digest, Sha512};
 
 use frost_core::{frost, Ciphersuite, Field, Group};
 
@@ -106,6 +106,21 @@ impl Group for RistrettoGroup {
     }
 }
 
+fn hash_to_array(inputs: &[&[u8]]) -> [u8; 64] {
+    let mut h = Sha512::new();
+    for i in inputs {
+        h.update(i);
+    }
+    let mut output = [0u8; 64];
+    output.copy_from_slice(h.finalize().as_slice());
+    output
+}
+
+fn hash_to_scalar(inputs: &[&[u8]]) -> Scalar {
+    let output = hash_to_array(inputs);
+    Scalar::from_bytes_mod_order_wide(&output)
+}
+
 /// Context string from the ciphersuite in the [spec].
 ///
 /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.2-1
@@ -126,82 +141,40 @@ impl Ciphersuite for Ristretto255Sha512 {
     ///
     /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.2-2.2.2.1
     fn H1(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
-        let h = Sha512::new()
-            .chain(CONTEXT_STRING.as_bytes())
-            .chain("rho")
-            .chain(m);
-
-        let mut output = [0u8; 64];
-        output.copy_from_slice(h.finalize().as_slice());
-        <<Self::Group as Group>::Field as Field>::Scalar::from_bytes_mod_order_wide(&output)
+        hash_to_scalar(&[CONTEXT_STRING.as_bytes(), b"rho", m])
     }
 
     /// H2 for FROST(ristretto255, SHA-512)
     ///
     /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.2-2.2.2.2
     fn H2(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
-        let h = Sha512::new()
-            .chain(CONTEXT_STRING.as_bytes())
-            .chain("chal")
-            .chain(m);
-
-        let mut output = [0u8; 64];
-        output.copy_from_slice(h.finalize().as_slice());
-        <<Self::Group as Group>::Field as Field>::Scalar::from_bytes_mod_order_wide(&output)
+        hash_to_scalar(&[CONTEXT_STRING.as_bytes(), b"chal", m])
     }
 
     /// H3 for FROST(ristretto255, SHA-512)
     ///
     /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.2-2.2.2.3
     fn H3(m: &[u8]) -> <<Self::Group as Group>::Field as Field>::Scalar {
-        let h = Sha512::new()
-            .chain(CONTEXT_STRING.as_bytes())
-            .chain("nonce")
-            .chain(m);
-
-        let mut output = [0u8; 64];
-        output.copy_from_slice(h.finalize().as_slice());
-        <<Self::Group as Group>::Field as Field>::Scalar::from_bytes_mod_order_wide(&output)
+        hash_to_scalar(&[CONTEXT_STRING.as_bytes(), b"nonce", m])
     }
 
     /// H4 for FROST(ristretto255, SHA-512)
     ///
     /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.2-2.2.2.4
     fn H4(m: &[u8]) -> Self::HashOutput {
-        let h = Sha512::new()
-            .chain(CONTEXT_STRING.as_bytes())
-            .chain("msg")
-            .chain(m);
-
-        let mut output = [0u8; 64];
-        output.copy_from_slice(h.finalize().as_slice());
-        output
+        hash_to_array(&[CONTEXT_STRING.as_bytes(), b"msg", m])
     }
 
     /// H5 for FROST(ristretto255, SHA-512)
     ///
     /// [spec]: https://www.ietf.org/archive/id/draft-irtf-cfrg-frost-11.html#section-6.2-2.2.2.5
     fn H5(m: &[u8]) -> Self::HashOutput {
-        let h = Sha512::new()
-            .chain(CONTEXT_STRING.as_bytes())
-            .chain("com")
-            .chain(m);
-
-        let mut output = [0u8; 64];
-        output.copy_from_slice(h.finalize().as_slice());
-        output
+        hash_to_array(&[CONTEXT_STRING.as_bytes(), b"com", m])
     }
 
     /// HDKG for FROST(ristretto255, SHA-512)
     fn HDKG(m: &[u8]) -> Option<<<Self::Group as Group>::Field as Field>::Scalar> {
-        let h = Sha512::new()
-            .chain(CONTEXT_STRING.as_bytes())
-            .chain("dkg")
-            .chain(m);
-
-        let mut output = [0u8; 64];
-        output.copy_from_slice(h.finalize().as_slice());
-        Some(<<Self::Group as Group>::Field as Field>::Scalar::from_bytes_mod_order_wide(&output))
+        Some(hash_to_scalar(&[CONTEXT_STRING.as_bytes(), b"dkg", m]))
     }
 }
 


### PR DESCRIPTION
For Ed448 I tried to reduce code duplication with two helper functions; here I did the same for the remaining ciphersuites