### PR TITLE
add ed25519 interoperability test

### DIFF
--- a/frost-ed25519/tests/frost.rs
+++ b/frost-ed25519/tests/frost.rs
@@ -1,20 +1,50 @@
-use curve25519_dalek::{edwards::EdwardsPoint, traits::Identity};
 use frost_core::{Ciphersuite, Group, GroupError};
 use frost_ed25519::*;
+
+use curve25519_dalek::{edwards::EdwardsPoint, traits::Identity};
+use ed25519_dalek::Verifier;
 use rand::thread_rng;
+
+fn verify_signature(
+    msg: &[u8],
+    group_signature: frost_core::Signature<Ed25519Sha512>,
+    group_pubkey: frost_core::VerifyingKey<Ed25519Sha512>,
+) {
+    let sig = {
+        let bytes: [u8; 64] = group_signature.to_bytes();
+        ed25519_dalek::Signature::from(bytes)
+    };
+    let pub_key = {
+        let bytes = group_pubkey.to_bytes();
+        ed25519_dalek::PublicKey::from_bytes(&bytes).unwrap()
+    };
+    // Check that signature validation has the expected result.
+    assert!(pub_key.verify(msg, &sig).is_ok());
+}
 
 #[test]
 fn check_sign_with_dealer() {
     let rng = thread_rng();
 
-    frost_core::tests::check_sign_with_dealer::<Ed25519Sha512, _>(rng);
+    // For the interoperability test it's better to test with multiple signatures
+    for _ in 0..256 {
+        let (msg, group_signature, group_pubkey) =
+            frost_core::tests::check_sign_with_dealer::<Ed25519Sha512, _>(rng.clone());
+
+        // Check that the threshold signature can be verified by the `ed25519_dalek` crate
+        // public key (interoperability test)
+        verify_signature(&msg, group_signature, group_pubkey);
+    }
 }
 
 #[test]
 fn check_sign_with_dkg() {
     let rng = thread_rng();
 
-    frost_core::tests::check_sign_with_dkg::<Ed25519Sha512, _>(rng);
+    let (msg, group_signature, group_pubkey) =
+        frost_core::tests::check_sign_with_dkg::<Ed25519Sha512, _>(rng);
+
+    verify_signature(&msg, group_signature, group_pubkey);
 }
 
 #[test]

--- a/frost-ed25519/tests/frost.rs
+++ b/frost-ed25519/tests/frost.rs
@@ -26,7 +26,8 @@ fn verify_signature(
 fn check_sign_with_dealer() {
     let rng = thread_rng();
 
-    // For the interoperability test it's better to test with multiple signatures
+    // Test with multiple keys/signatures to better exercise the key generation
+    // and the interoperability check.
     for _ in 0..256 {
         let (msg, group_signature, group_pubkey) =
             frost_core::tests::check_sign_with_dealer::<Ed25519Sha512, _>(rng.clone());
@@ -41,10 +42,15 @@ fn check_sign_with_dealer() {
 fn check_sign_with_dkg() {
     let rng = thread_rng();
 
-    let (msg, group_signature, group_pubkey) =
-        frost_core::tests::check_sign_with_dkg::<Ed25519Sha512, _>(rng);
+    // Test with multiple keys/signatures to better exercise the key generation
+    // and the interoperability check. A smaller number of iterations is used
+    // because DKG takes longer and otherwise the test would be too slow.
+    for _ in 0..32 {
+        let (msg, group_signature, group_pubkey) =
+            frost_core::tests::check_sign_with_dkg::<Ed25519Sha512, _>(rng.clone());
 
-    verify_signature(&msg, group_signature, group_pubkey);
+        verify_signature(&msg, group_signature, group_pubkey);
+    }
 }
 
 #[test]


### PR DESCRIPTION
After adding a similar test for [Jubjub and Pallas](https://github.com/ZcashFoundation/reddsa/pull/33/), I added a test to ensure that FROST-generate sigs can be validated by other crates.

I had great ambitions of adding this for every ciphersuite but then realized:

- Couldn't find Ed448 sig verification (Ed448-Goldilocks doesn't have it yet)
- Existing Ristretto Schnorr impls ([starsig](https://docs.rs/starsig/latest/starsig/), [schnorrkel](https://docs.rs/schnorrkel/latest/schnorrkel/index.html)) use fancy transcripts which are incompatible
- No existing P-256 Schnorr implementation (I guess we just invented it? :rofl: )
- No existing secp256k1 Schnorr implementations (Taproot is stricter)

I didn't look too hard though so we might revisit this.