### PR TITLE
rename DKG types

### DIFF
--- a/frost-core/src/tests.rs
+++ b/frost-core/src/tests.rs
@@ -166,7 +166,7 @@ where
     // will have all the participant's packages.
     let mut round1_secret_packages: HashMap<
         frost::Identifier<C>,
-        frost::keys::dkg::Round1SecretPackage<C>,
+        frost::keys::dkg::round1::SecretPackage<C>,
     > = HashMap::new();
 
     // Keep track of all round 1 packages sent to the given participant.
@@ -174,20 +174,16 @@ where
     // will be sent through some communication channel.
     let mut received_round1_packages: HashMap<
         frost::Identifier<C>,
-        Vec<frost::keys::dkg::Round1Package<C>>,
+        Vec<frost::keys::dkg::round1::Package<C>>,
     > = HashMap::new();
 
     // For each participant, perform the first part of the DKG protocol.
     // In practice, each participant will perform this on their own environments.
     for participant_index in 1..=max_signers {
         let participant_identifier = participant_index.try_into().expect("should be nonzero");
-        let (secret_package, round1_package) = frost::keys::dkg::keygen_part1(
-            participant_identifier,
-            max_signers,
-            min_signers,
-            &mut rng,
-        )
-        .unwrap();
+        let (secret_package, round1_package) =
+            frost::keys::dkg::part1(participant_identifier, max_signers, min_signers, &mut rng)
+                .unwrap();
 
         // Store the participant's secret package for later use.
         // In practice each participant will store it in their own environment.
@@ -228,7 +224,7 @@ where
     // In practice, each participant will perform this on their own environments.
     for participant_index in 1..=max_signers {
         let participant_identifier = participant_index.try_into().expect("should be nonzero");
-        let (round2_secret_package, round2_packages) = frost::keys::dkg::keygen_part2(
+        let (round2_secret_package, round2_packages) = frost::keys::dkg::part2(
             round1_secret_packages
                 .remove(&participant_identifier)
                 .unwrap(),
@@ -281,7 +277,7 @@ where
     // In practice, each participant will perform this on their own environments.
     for participant_index in 1..=max_signers {
         let participant_identifier = participant_index.try_into().expect("should be nonzero");
-        let (key_package, pubkey_package_for_participant) = frost::keys::dkg::keygen_part3(
+        let (key_package, pubkey_package_for_participant) = frost::keys::dkg::part3(
             &round2_secret_packages[&participant_identifier],
             &received_round1_packages[&participant_identifier],
             &received_round2_packages[&participant_identifier],

--- a/frost-ed25519/dkg.md
+++ b/frost-ed25519/dkg.md
@@ -9,12 +9,12 @@ a `u16`. The process in which these identifiers are allocated is up to the appli
 The distributed key generation process has 3 parts, with 2 communication rounds
 between them, in which each participant needs to send a "package" to every other
 participant. In the first round, each participant sends the same package
-(a [`Round1Package`]) to every other. In the second round, each receiver gets
-their own package (a [`Round2Package`]).
+(a [`round1::Package`]) to every other. In the second round, each receiver gets
+their own package (a [`round2::Package`]).
 
-Between part 1 and 2, each participant needs to hold onto a [`Round1SecretPackage`]
+Between part 1 and 2, each participant needs to hold onto a [`round1::SecretPackage`]
 that MUST be kept secret. Between part 2 and 3, each participant needs to hold
-onto a [`Round2SecretPackage`].
+onto a [`round2::SecretPackage`].
 
 After the third part, each participant will get a [`KeyPackage`] with their
 long-term secret share that must be kept secret, and a [`PublicKeyPackage`]
@@ -53,7 +53,7 @@ let mut received_round1_packages = HashMap::new();
 // In practice, each participant will perform this on their own environments.
 for participant_index in 1..=max_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
-    let (secret_package, round1_package) = frost::keys::dkg::keygen_part1(
+    let (secret_package, round1_package) = frost::keys::dkg::part1(
         participant_identifier,
         max_signers,
         min_signers,
@@ -99,7 +99,7 @@ let mut received_round2_packages = HashMap::new();
 // In practice, each participant will perform this on their own environments.
 for participant_index in 1..=max_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
-    let (round2_secret_package, round2_packages) = frost::keys::dkg::keygen_part2(
+    let (round2_secret_package, round2_packages) = frost::keys::dkg::part2(
         round1_secret_packages
             .remove(&participant_identifier)
             .unwrap(),
@@ -142,7 +142,7 @@ let mut pubkey_packages = HashMap::new();
 // In practice, each participant will perform this on their own environments.
 for participant_index in 1..=max_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
-    let (key_package, pubkey_package_for_participant) = frost::keys::dkg::keygen_part3(
+    let (key_package, pubkey_package_for_participant) = frost::keys::dkg::part3(
         &round2_secret_packages[&participant_identifier],
         &received_round1_packages[&participant_identifier],
         &received_round2_packages[&participant_identifier],

--- a/frost-ed25519/src/keys/dkg.rs
+++ b/frost-ed25519/src/keys/dkg.rs
@@ -1,77 +1,87 @@
 #![doc = include_str!("../../dkg.md")]
 use super::*;
 
-/// The secret package that must be kept in memory by the participant
-/// between the first and second parts of the DKG protocol (round 1).
-///
-/// # Security
-///
-/// This package MUST NOT be sent to other participants!
-pub type Round1SecretPackage = frost::keys::dkg::Round1SecretPackage<E>;
+/// DKG Round 1 structures.
+pub mod round1 {
+    use super::*;
 
-/// The package that must be broadcast by each participant to all other participants
-/// between the first and second parts of the DKG protocol (round 1).
-pub type Round1Package = frost::keys::dkg::Round1Package<E>;
+    /// The secret package that must be kept in memory by the participant
+    /// between the first and second parts of the DKG protocol (round 1).
+    ///
+    /// # Security
+    ///
+    /// This package MUST NOT be sent to other participants!
+    pub type SecretPackage = frost::keys::dkg::round1::SecretPackage<E>;
 
-/// The secret package that must be kept in memory by the participant
-/// between the second and third parts of the DKG protocol (round 2).
-///
-/// # Security
-///
-/// This package MUST NOT be sent to other participants!
-pub type Round2SecretPackage = frost::keys::dkg::Round2SecretPackage<E>;
+    /// The package that must be broadcast by each participant to all other participants
+    /// between the first and second parts of the DKG protocol (round 1).
+    pub type Package = frost::keys::dkg::round1::Package<E>;
+}
 
-/// A package that must be sent by each participant to some other participants
-/// in Round 2 of the DKG protocol. Note that there is one specific package
-/// for each specific recipient, in contrast to Round 1.
-///
-/// # Security
-///
-/// The package must be sent on an *confidential* and *authenticated* channel.
-pub type Round2Package = frost::keys::dkg::Round2Package<E>;
+/// DKG Round 2 structures.
+pub mod round2 {
+    use super::*;
+
+    /// The secret package that must be kept in memory by the participant
+    /// between the second and third parts of the DKG protocol (round 2).
+    ///
+    /// # Security
+    ///
+    /// This package MUST NOT be sent to other participants!
+    pub type SecretPackage = frost::keys::dkg::round2::SecretPackage<E>;
+
+    /// A package that must be sent by each participant to some other participants
+    /// in Round 2 of the DKG protocol. Note that there is one specific package
+    /// for each specific recipient, in contrast to Round 1.
+    ///
+    /// # Security
+    ///
+    /// The package must be sent on an *confidential* and *authenticated* channel.
+    pub type Package = frost::keys::dkg::round2::Package<E>;
+}
 
 /// Performs the first part of the distributed key generation protocol
 /// for the given participant.
 ///
-/// It returns the [`Round1SecretPackage`] that must be kept in memory
-/// by the participant for the other steps, and the [`Round1Package`] that
+/// It returns the [`round1::SecretPackage`] that must be kept in memory
+/// by the participant for the other steps, and the [`round1::Package`] that
 /// must be sent to other participants.
-pub fn keygen_part1<R: RngCore + CryptoRng>(
+pub fn part1<R: RngCore + CryptoRng>(
     identifier: Identifier,
     max_signers: u16,
     min_signers: u16,
     mut rng: R,
-) -> Result<(Round1SecretPackage, Round1Package), Error> {
-    frost::keys::dkg::keygen_part1(identifier, max_signers, min_signers, &mut rng)
+) -> Result<(round1::SecretPackage, round1::Package), Error> {
+    frost::keys::dkg::part1(identifier, max_signers, min_signers, &mut rng)
 }
 
 /// Performs the second part of the distributed key generation protocol
-/// for the participant holding the given [`Round1SecretPackage`],
-/// given the received [`Round1Package`]s received from the other participants.
+/// for the participant holding the given [`round1::SecretPackage`],
+/// given the received [`round1::Package`]s received from the other participants.
 ///
-/// It returns the [`Round2SecretPackage`] that must be kept in memory
-/// by the participant for the final step, and the [`Round2Package`]s that
+/// It returns the [`round2::SecretPackage`] that must be kept in memory
+/// by the participant for the final step, and the [`round2::Package`]s that
 /// must be sent to other participants.
-pub fn keygen_part2(
-    secret_package: Round1SecretPackage,
-    round1_packages: &[Round1Package],
-) -> Result<(Round2SecretPackage, Vec<Round2Package>), Error> {
-    frost::keys::dkg::keygen_part2(secret_package, round1_packages)
+pub fn part2(
+    secret_package: round1::SecretPackage,
+    round1_packages: &[round1::Package],
+) -> Result<(round2::SecretPackage, Vec<round2::Package>), Error> {
+    frost::keys::dkg::part2(secret_package, round1_packages)
 }
 
 /// Performs the third and final part of the distributed key generation protocol
-/// for the participant holding the given [`Round2SecretPackage`],
-/// given the received [`Round1Package`]s and [`Round2Package`]s received from
+/// for the participant holding the given [`round2::SecretPackage`],
+/// given the received [`round1::Package`]s and [`round2::Package`]s received from
 /// the other participants.
 ///
 /// It returns the [`KeyPackage`] that has the long-lived key share for the
 /// participant, and the [`PublicKeyPackage`]s that has public information
 /// about all participants; both of which are required to compute FROST
 /// signatures.
-pub fn keygen_part3(
-    round2_secret_package: &Round2SecretPackage,
-    round1_packages: &[Round1Package],
-    round2_packages: &[Round2Package],
+pub fn part3(
+    round2_secret_package: &round2::SecretPackage,
+    round1_packages: &[round1::Package],
+    round2_packages: &[round2::Package],
 ) -> Result<(KeyPackage, PublicKeyPackage), Error> {
-    frost::keys::dkg::keygen_part3(round2_secret_package, round1_packages, round2_packages)
+    frost::keys::dkg::part3(round2_secret_package, round1_packages, round2_packages)
 }

--- a/frost-ed448/dkg.md
+++ b/frost-ed448/dkg.md
@@ -9,12 +9,12 @@ a `u16`. The process in which these identifiers are allocated is up to the appli
 The distributed key generation process has 3 parts, with 2 communication rounds
 between them, in which each participant needs to send a "package" to every other
 participant. In the first round, each participant sends the same package
-(a [`Round1Package`]) to every other. In the second round, each receiver gets
-their own package (a [`Round2Package`]).
+(a [`round1::Package`]) to every other. In the second round, each receiver gets
+their own package (a [`round2::Package`]).
 
-Between part 1 and 2, each participant needs to hold onto a [`Round1SecretPackage`]
+Between part 1 and 2, each participant needs to hold onto a [`round1::SecretPackage`]
 that MUST be kept secret. Between part 2 and 3, each participant needs to hold
-onto a [`Round2SecretPackage`].
+onto a [`round2::SecretPackage`].
 
 After the third part, each participant will get a [`KeyPackage`] with their
 long-term secret share that must be kept secret, and a [`PublicKeyPackage`]
@@ -53,7 +53,7 @@ let mut received_round1_packages = HashMap::new();
 // In practice, each participant will perform this on their own environments.
 for participant_index in 1..=max_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
-    let (secret_package, round1_package) = frost::keys::dkg::keygen_part1(
+    let (secret_package, round1_package) = frost::keys::dkg::part1(
         participant_identifier,
         max_signers,
         min_signers,
@@ -99,7 +99,7 @@ let mut received_round2_packages = HashMap::new();
 // In practice, each participant will perform this on their own environments.
 for participant_index in 1..=max_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
-    let (round2_secret_package, round2_packages) = frost::keys::dkg::keygen_part2(
+    let (round2_secret_package, round2_packages) = frost::keys::dkg::part2(
         round1_secret_packages
             .remove(&participant_identifier)
             .unwrap(),
@@ -142,7 +142,7 @@ let mut pubkey_packages = HashMap::new();
 // In practice, each participant will perform this on their own environments.
 for participant_index in 1..=max_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
-    let (key_package, pubkey_package_for_participant) = frost::keys::dkg::keygen_part3(
+    let (key_package, pubkey_package_for_participant) = frost::keys::dkg::part3(
         &round2_secret_packages[&participant_identifier],
         &received_round1_packages[&participant_identifier],
         &received_round2_packages[&participant_identifier],

--- a/frost-ed448/src/keys/dkg.rs
+++ b/frost-ed448/src/keys/dkg.rs
@@ -1,77 +1,87 @@
 #![doc = include_str!("../../dkg.md")]
 use super::*;
 
-/// The secret package that must be kept in memory by the participant
-/// between the first and second parts of the DKG protocol (round 1).
-///
-/// # Security
-///
-/// This package MUST NOT be sent to other participants!
-pub type Round1SecretPackage = frost::keys::dkg::Round1SecretPackage<E>;
+/// DKG Round 1 structures.
+pub mod round1 {
+    use super::*;
 
-/// The package that must be broadcast by each participant to all other participants
-/// between the first and second parts of the DKG protocol (round 1).
-pub type Round1Package = frost::keys::dkg::Round1Package<E>;
+    /// The secret package that must be kept in memory by the participant
+    /// between the first and second parts of the DKG protocol (round 1).
+    ///
+    /// # Security
+    ///
+    /// This package MUST NOT be sent to other participants!
+    pub type SecretPackage = frost::keys::dkg::round1::SecretPackage<E>;
 
-/// The secret package that must be kept in memory by the participant
-/// between the second and third parts of the DKG protocol (round 2).
-///
-/// # Security
-///
-/// This package MUST NOT be sent to other participants!
-pub type Round2SecretPackage = frost::keys::dkg::Round2SecretPackage<E>;
+    /// The package that must be broadcast by each participant to all other participants
+    /// between the first and second parts of the DKG protocol (round 1).
+    pub type Package = frost::keys::dkg::round1::Package<E>;
+}
 
-/// A package that must be sent by each participant to some other participants
-/// in Round 2 of the DKG protocol. Note that there is one specific package
-/// for each specific recipient, in contrast to Round 1.
-///
-/// # Security
-///
-/// The package must be sent on an *confidential* and *authenticated* channel.
-pub type Round2Package = frost::keys::dkg::Round2Package<E>;
+/// DKG Round 2 structures.
+pub mod round2 {
+    use super::*;
+
+    /// The secret package that must be kept in memory by the participant
+    /// between the second and third parts of the DKG protocol (round 2).
+    ///
+    /// # Security
+    ///
+    /// This package MUST NOT be sent to other participants!
+    pub type SecretPackage = frost::keys::dkg::round2::SecretPackage<E>;
+
+    /// A package that must be sent by each participant to some other participants
+    /// in Round 2 of the DKG protocol. Note that there is one specific package
+    /// for each specific recipient, in contrast to Round 1.
+    ///
+    /// # Security
+    ///
+    /// The package must be sent on an *confidential* and *authenticated* channel.
+    pub type Package = frost::keys::dkg::round2::Package<E>;
+}
 
 /// Performs the first part of the distributed key generation protocol
 /// for the given participant.
 ///
-/// It returns the [`Round1SecretPackage`] that must be kept in memory
-/// by the participant for the other steps, and the [`Round1Package`] that
+/// It returns the [`round1::SecretPackage`] that must be kept in memory
+/// by the participant for the other steps, and the [`round1::Package`] that
 /// must be sent to other participants.
-pub fn keygen_part1<R: RngCore + CryptoRng>(
+pub fn part1<R: RngCore + CryptoRng>(
     identifier: Identifier,
     max_signers: u16,
     min_signers: u16,
     mut rng: R,
-) -> Result<(Round1SecretPackage, Round1Package), Error> {
-    frost::keys::dkg::keygen_part1(identifier, max_signers, min_signers, &mut rng)
+) -> Result<(round1::SecretPackage, round1::Package), Error> {
+    frost::keys::dkg::part1(identifier, max_signers, min_signers, &mut rng)
 }
 
 /// Performs the second part of the distributed key generation protocol
-/// for the participant holding the given [`Round1SecretPackage`],
-/// given the received [`Round1Package`]s received from the other participants.
+/// for the participant holding the given [`round1::SecretPackage`],
+/// given the received [`round1::Package`]s received from the other participants.
 ///
-/// It returns the [`Round2SecretPackage`] that must be kept in memory
-/// by the participant for the final step, and the [`Round2Package`]s that
+/// It returns the [`round2::SecretPackage`] that must be kept in memory
+/// by the participant for the final step, and the [`round2::Package`]s that
 /// must be sent to other participants.
-pub fn keygen_part2(
-    secret_package: Round1SecretPackage,
-    round1_packages: &[Round1Package],
-) -> Result<(Round2SecretPackage, Vec<Round2Package>), Error> {
-    frost::keys::dkg::keygen_part2(secret_package, round1_packages)
+pub fn part2(
+    secret_package: round1::SecretPackage,
+    round1_packages: &[round1::Package],
+) -> Result<(round2::SecretPackage, Vec<round2::Package>), Error> {
+    frost::keys::dkg::part2(secret_package, round1_packages)
 }
 
 /// Performs the third and final part of the distributed key generation protocol
-/// for the participant holding the given [`Round2SecretPackage`],
-/// given the received [`Round1Package`]s and [`Round2Package`]s received from
+/// for the participant holding the given [`round2::SecretPackage`],
+/// given the received [`round1::Package`]s and [`round2::Package`]s received from
 /// the other participants.
 ///
 /// It returns the [`KeyPackage`] that has the long-lived key share for the
 /// participant, and the [`PublicKeyPackage`]s that has public information
 /// about all participants; both of which are required to compute FROST
 /// signatures.
-pub fn keygen_part3(
-    round2_secret_package: &Round2SecretPackage,
-    round1_packages: &[Round1Package],
-    round2_packages: &[Round2Package],
+pub fn part3(
+    round2_secret_package: &round2::SecretPackage,
+    round1_packages: &[round1::Package],
+    round2_packages: &[round2::Package],
 ) -> Result<(KeyPackage, PublicKeyPackage), Error> {
-    frost::keys::dkg::keygen_part3(round2_secret_package, round1_packages, round2_packages)
+    frost::keys::dkg::part3(round2_secret_package, round1_packages, round2_packages)
 }

--- a/frost-p256/dkg.md
+++ b/frost-p256/dkg.md
@@ -9,12 +9,12 @@ a `u16`. The process in which these identifiers are allocated is up to the appli
 The distributed key generation process has 3 parts, with 2 communication rounds
 between them, in which each participant needs to send a "package" to every other
 participant. In the first round, each participant sends the same package
-(a [`Round1Package`]) to every other. In the second round, each receiver gets
-their own package (a [`Round2Package`]).
+(a [`round1::Package`]) to every other. In the second round, each receiver gets
+their own package (a [`round2::Package`]).
 
-Between part 1 and 2, each participant needs to hold onto a [`Round1SecretPackage`]
+Between part 1 and 2, each participant needs to hold onto a [`round1::SecretPackage`]
 that MUST be kept secret. Between part 2 and 3, each participant needs to hold
-onto a [`Round2SecretPackage`].
+onto a [`round2::SecretPackage`].
 
 After the third part, each participant will get a [`KeyPackage`] with their
 long-term secret share that must be kept secret, and a [`PublicKeyPackage`]
@@ -53,7 +53,7 @@ let mut received_round1_packages = HashMap::new();
 // In practice, each participant will perform this on their own environments.
 for participant_index in 1..=max_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
-    let (secret_package, round1_package) = frost::keys::dkg::keygen_part1(
+    let (secret_package, round1_package) = frost::keys::dkg::part1(
         participant_identifier,
         max_signers,
         min_signers,
@@ -99,7 +99,7 @@ let mut received_round2_packages = HashMap::new();
 // In practice, each participant will perform this on their own environments.
 for participant_index in 1..=max_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
-    let (round2_secret_package, round2_packages) = frost::keys::dkg::keygen_part2(
+    let (round2_secret_package, round2_packages) = frost::keys::dkg::part2(
         round1_secret_packages
             .remove(&participant_identifier)
             .unwrap(),
@@ -142,7 +142,7 @@ let mut pubkey_packages = HashMap::new();
 // In practice, each participant will perform this on their own environments.
 for participant_index in 1..=max_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
-    let (key_package, pubkey_package_for_participant) = frost::keys::dkg::keygen_part3(
+    let (key_package, pubkey_package_for_participant) = frost::keys::dkg::part3(
         &round2_secret_packages[&participant_identifier],
         &received_round1_packages[&participant_identifier],
         &received_round2_packages[&participant_identifier],

--- a/frost-p256/src/keys/dkg.rs
+++ b/frost-p256/src/keys/dkg.rs
@@ -1,77 +1,87 @@
 #![doc = include_str!("../../dkg.md")]
 use super::*;
 
-/// The secret package that must be kept in memory by the participant
-/// between the first and second parts of the DKG protocol (round 1).
-///
-/// # Security
-///
-/// This package MUST NOT be sent to other participants!
-pub type Round1SecretPackage = frost::keys::dkg::Round1SecretPackage<P>;
+/// DKG Round 1 structures.
+pub mod round1 {
+    use super::*;
 
-/// The package that must be broadcast by each participant to all other participants
-/// between the first and second parts of the DKG protocol (round 1).
-pub type Round1Package = frost::keys::dkg::Round1Package<P>;
+    /// The secret package that must be kept in memory by the participant
+    /// between the first and second parts of the DKG protocol (round 1).
+    ///
+    /// # Security
+    ///
+    /// This package MUST NOT be sent to other participants!
+    pub type SecretPackage = frost::keys::dkg::round1::SecretPackage<P>;
 
-/// The secret package that must be kept in memory by the participant
-/// between the second and third parts of the DKG protocol (round 2).
-///
-/// # Security
-///
-/// This package MUST NOT be sent to other participants!
-pub type Round2SecretPackage = frost::keys::dkg::Round2SecretPackage<P>;
+    /// The package that must be broadcast by each participant to all other participants
+    /// between the first and second parts of the DKG protocol (round 1).
+    pub type Package = frost::keys::dkg::round1::Package<P>;
+}
 
-/// A package that must be sent by each participant to some other participants
-/// in Round 2 of the DKG protocol. Note that there is one specific package
-/// for each specific recipient, in contrast to Round 1.
-///
-/// # Security
-///
-/// The package must be sent on an *confidential* and *authenticated* channel.
-pub type Round2Package = frost::keys::dkg::Round2Package<P>;
+/// DKG Round 2 structures.
+pub mod round2 {
+    use super::*;
+
+    /// The secret package that must be kept in memory by the participant
+    /// between the second and third parts of the DKG protocol (round 2).
+    ///
+    /// # Security
+    ///
+    /// This package MUST NOT be sent to other participants!
+    pub type SecretPackage = frost::keys::dkg::round2::SecretPackage<P>;
+
+    /// A package that must be sent by each participant to some other participants
+    /// in Round 2 of the DKG protocol. Note that there is one specific package
+    /// for each specific recipient, in contrast to Round 1.
+    ///
+    /// # Security
+    ///
+    /// The package must be sent on an *confidential* and *authenticated* channel.
+    pub type Package = frost::keys::dkg::round2::Package<P>;
+}
 
 /// Performs the first part of the distributed key generation protocol
 /// for the given participant.
 ///
-/// It returns the [`Round1SecretPackage`] that must be kept in memory
-/// by the participant for the other steps, and the [`Round1Package`] that
+/// It returns the [`round1::SecretPackage`] that must be kept in memory
+/// by the participant for the other steps, and the [`round1::Package`] that
 /// must be sent to other participants.
-pub fn keygen_part1<R: RngCore + CryptoRng>(
+pub fn part1<R: RngCore + CryptoRng>(
     identifier: Identifier,
     max_signers: u16,
     min_signers: u16,
     mut rng: R,
-) -> Result<(Round1SecretPackage, Round1Package), Error> {
-    frost::keys::dkg::keygen_part1(identifier, max_signers, min_signers, &mut rng)
+) -> Result<(round1::SecretPackage, round1::Package), Error> {
+    frost::keys::dkg::part1(identifier, max_signers, min_signers, &mut rng)
 }
 
 /// Performs the second part of the distributed key generation protocol
-/// for the participant holding the given [`Round1SecretPackage`],
-/// given the received [`Round1Package`]s received from the other participants.
+/// for the participant holding the given [`round1::SecretPackage`],
+/// given the received [`round1::Package`]s received from the other participants.
 ///
-/// It returns the [`Round2SecretPackage`] that must be kept in memory
-/// by the participant for the final step, and the [`Round2Package`]s that
+/// It returns the [`round2::SecretPackage`] that must be kept in memory
+/// by the participant for the final step, and the [`round2::Package`]s that
 /// must be sent to other participants.
-pub fn keygen_part2(
-    secret_package: Round1SecretPackage,
-    round1_packages: &[Round1Package],
-) -> Result<(Round2SecretPackage, Vec<Round2Package>), Error> {
-    frost::keys::dkg::keygen_part2(secret_package, round1_packages)
+pub fn part2(
+    secret_package: round1::SecretPackage,
+    round1_packages: &[round1::Package],
+) -> Result<(round2::SecretPackage, Vec<round2::Package>), Error> {
+    frost::keys::dkg::part2(secret_package, round1_packages)
 }
 
 /// Performs the third and final part of the distributed key generation protocol
-/// for the participant holding the given [`Round2SecretPackage`],
-/// given the received [`Round1Package`]s and [`Round2Package`]s received from
+/// for the participant holding the given [`round2::SecretPackage`],
+/// given the received [`round1::Package`]s and [`round2::Package`]s received from
 /// the other participants.
 ///
 /// It returns the [`KeyPackage`] that has the long-lived key share for the
 /// participant, and the [`PublicKeyPackage`]s that has public information
 /// about all participants; both of which are required to compute FROST
 /// signatures.
-pub fn keygen_part3(
-    round2_secret_package: &Round2SecretPackage,
-    round1_packages: &[Round1Package],
-    round2_packages: &[Round2Package],
+pub fn part3(
+    round2_secret_package: &round2::SecretPackage,
+    round1_packages: &[round1::Package],
+    round2_packages: &[round2::Package],
 ) -> Result<(KeyPackage, PublicKeyPackage), Error> {
-    frost::keys::dkg::keygen_part3(round2_secret_package, round1_packages, round2_packages)
+    frost::keys::dkg::part3(round2_secret_package, round1_packages, round2_packages)
 }

--- a/frost-ristretto255/dkg.md
+++ b/frost-ristretto255/dkg.md
@@ -9,12 +9,12 @@ a `u16`. The process in which these identifiers are allocated is up to the appli
 The distributed key generation process has 3 parts, with 2 communication rounds
 between them, in which each participant needs to send a "package" to every other
 participant. In the first round, each participant sends the same package
-(a [`Round1Package`]) to every other. In the second round, each receiver gets
-their own package (a [`Round2Package`]).
+(a [`round1::Package`]) to every other. In the second round, each receiver gets
+their own package (a [`round2::Package`]).
 
-Between part 1 and 2, each participant needs to hold onto a [`Round1SecretPackage`]
+Between part 1 and 2, each participant needs to hold onto a [`round1::SecretPackage`]
 that MUST be kept secret. Between part 2 and 3, each participant needs to hold
-onto a [`Round2SecretPackage`].
+onto a [`round2::SecretPackage`].
 
 After the third part, each participant will get a [`KeyPackage`] with their
 long-term secret share that must be kept secret, and a [`PublicKeyPackage`]
@@ -53,7 +53,7 @@ let mut received_round1_packages = HashMap::new();
 // In practice, each participant will perform this on their own environments.
 for participant_index in 1..=max_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
-    let (secret_package, round1_package) = frost::keys::dkg::keygen_part1(
+    let (secret_package, round1_package) = frost::keys::dkg::part1(
         participant_identifier,
         max_signers,
         min_signers,
@@ -99,7 +99,7 @@ let mut received_round2_packages = HashMap::new();
 // In practice, each participant will perform this on their own environments.
 for participant_index in 1..=max_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
-    let (round2_secret_package, round2_packages) = frost::keys::dkg::keygen_part2(
+    let (round2_secret_package, round2_packages) = frost::keys::dkg::part2(
         round1_secret_packages
             .remove(&participant_identifier)
             .unwrap(),
@@ -142,7 +142,7 @@ let mut pubkey_packages = HashMap::new();
 // In practice, each participant will perform this on their own environments.
 for participant_index in 1..=max_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
-    let (key_package, pubkey_package_for_participant) = frost::keys::dkg::keygen_part3(
+    let (key_package, pubkey_package_for_participant) = frost::keys::dkg::part3(
         &round2_secret_packages[&participant_identifier],
         &received_round1_packages[&participant_identifier],
         &received_round2_packages[&participant_identifier],

--- a/frost-ristretto255/src/keys/dkg.rs
+++ b/frost-ristretto255/src/keys/dkg.rs
@@ -1,77 +1,87 @@
 #![doc = include_str!("../../dkg.md")]
 use super::*;
 
-/// The secret package that must be kept in memory by the participant
-/// between the first and second parts of the DKG protocol (round 1).
-///
-/// # Security
-///
-/// This package MUST NOT be sent to other participants!
-pub type Round1SecretPackage = frost::keys::dkg::Round1SecretPackage<R>;
+/// DKG Round 1 structures.
+pub mod round1 {
+    use super::*;
 
-/// The package that must be broadcast by each participant to all other participants
-/// between the first and second parts of the DKG protocol (round 1).
-pub type Round1Package = frost::keys::dkg::Round1Package<R>;
+    /// The secret package that must be kept in memory by the participant
+    /// between the first and second parts of the DKG protocol (round 1).
+    ///
+    /// # Security
+    ///
+    /// This package MUST NOT be sent to other participants!
+    pub type SecretPackage = frost::keys::dkg::round1::SecretPackage<R>;
 
-/// The secret package that must be kept in memory by the participant
-/// between the second and third parts of the DKG protocol (round 2).
-///
-/// # Security
-///
-/// This package MUST NOT be sent to other participants!
-pub type Round2SecretPackage = frost::keys::dkg::Round2SecretPackage<R>;
+    /// The package that must be broadcast by each participant to all other participants
+    /// between the first and second parts of the DKG protocol (round 1).
+    pub type Package = frost::keys::dkg::round1::Package<R>;
+}
 
-/// A package that must be sent by each participant to some other participants
-/// in Round 2 of the DKG protocol. Note that there is one specific package
-/// for each specific recipient, in contrast to Round 1.
-///
-/// # Security
-///
-/// The package must be sent on an *confidential* and *authenticated* channel.
-pub type Round2Package = frost::keys::dkg::Round2Package<R>;
+/// DKG Round 2 structures.
+pub mod round2 {
+    use super::*;
+
+    /// The secret package that must be kept in memory by the participant
+    /// between the second and third parts of the DKG protocol (round 2).
+    ///
+    /// # Security
+    ///
+    /// This package MUST NOT be sent to other participants!
+    pub type SecretPackage = frost::keys::dkg::round2::SecretPackage<R>;
+
+    /// A package that must be sent by each participant to some other participants
+    /// in Round 2 of the DKG protocol. Note that there is one specific package
+    /// for each specific recipient, in contrast to Round 1.
+    ///
+    /// # Security
+    ///
+    /// The package must be sent on an *confidential* and *authenticated* channel.
+    pub type Package = frost::keys::dkg::round2::Package<R>;
+}
 
 /// Performs the first part of the distributed key generation protocol
 /// for the given participant.
 ///
-/// It returns the [`Round1SecretPackage`] that must be kept in memory
-/// by the participant for the other steps, and the [`Round1Package`] that
+/// It returns the [`round1::SecretPackage`] that must be kept in memory
+/// by the participant for the other steps, and the [`round1::Package`] that
 /// must be sent to other participants.
-pub fn keygen_part1<R: RngCore + CryptoRng>(
+pub fn part1<R: RngCore + CryptoRng>(
     identifier: Identifier,
     max_signers: u16,
     min_signers: u16,
     mut rng: R,
-) -> Result<(Round1SecretPackage, Round1Package), Error> {
-    frost::keys::dkg::keygen_part1(identifier, max_signers, min_signers, &mut rng)
+) -> Result<(round1::SecretPackage, round1::Package), Error> {
+    frost::keys::dkg::part1(identifier, max_signers, min_signers, &mut rng)
 }
 
 /// Performs the second part of the distributed key generation protocol
-/// for the participant holding the given [`Round1SecretPackage`],
-/// given the received [`Round1Package`]s received from the other participants.
+/// for the participant holding the given [`round1::SecretPackage`],
+/// given the received [`round1::Package`]s received from the other participants.
 ///
-/// It returns the [`Round2SecretPackage`] that must be kept in memory
-/// by the participant for the final step, and the [`Round2Package`]s that
+/// It returns the [`round2::SecretPackage`] that must be kept in memory
+/// by the participant for the final step, and the [`round2::Package`]s that
 /// must be sent to other participants.
-pub fn keygen_part2(
-    secret_package: Round1SecretPackage,
-    round1_packages: &[Round1Package],
-) -> Result<(Round2SecretPackage, Vec<Round2Package>), Error> {
-    frost::keys::dkg::keygen_part2(secret_package, round1_packages)
+pub fn part2(
+    secret_package: round1::SecretPackage,
+    round1_packages: &[round1::Package],
+) -> Result<(round2::SecretPackage, Vec<round2::Package>), Error> {
+    frost::keys::dkg::part2(secret_package, round1_packages)
 }
 
 /// Performs the third and final part of the distributed key generation protocol
-/// for the participant holding the given [`Round2SecretPackage`],
-/// given the received [`Round1Package`]s and [`Round2Package`]s received from
+/// for the participant holding the given [`round2::SecretPackage`],
+/// given the received [`round1::Package`]s and [`round2::Package`]s received from
 /// the other participants.
 ///
 /// It returns the [`KeyPackage`] that has the long-lived key share for the
 /// participant, and the [`PublicKeyPackage`]s that has public information
 /// about all participants; both of which are required to compute FROST
 /// signatures.
-pub fn keygen_part3(
-    round2_secret_package: &Round2SecretPackage,
-    round1_packages: &[Round1Package],
-    round2_packages: &[Round2Package],
+pub fn part3(
+    round2_secret_package: &round2::SecretPackage,
+    round1_packages: &[round1::Package],
+    round2_packages: &[round2::Package],
 ) -> Result<(KeyPackage, PublicKeyPackage), Error> {
-    frost::keys::dkg::keygen_part3(round2_secret_package, round1_packages, round2_packages)
+    frost::keys::dkg::part3(round2_secret_package, round1_packages, round2_packages)
 }

--- a/frost-secp256k1/dkg.md
+++ b/frost-secp256k1/dkg.md
@@ -9,12 +9,12 @@ a `u16`. The process in which these identifiers are allocated is up to the appli
 The distributed key generation process has 3 parts, with 2 communication rounds
 between them, in which each participant needs to send a "package" to every other
 participant. In the first round, each participant sends the same package
-(a [`Round1Package`]) to every other. In the second round, each receiver gets
-their own package (a [`Round2Package`]).
+(a [`round1::Package`]) to every other. In the second round, each receiver gets
+their own package (a [`round2::Package`]).
 
-Between part 1 and 2, each participant needs to hold onto a [`Round1SecretPackage`]
+Between part 1 and 2, each participant needs to hold onto a [`round1::SecretPackage`]
 that MUST be kept secret. Between part 2 and 3, each participant needs to hold
-onto a [`Round2SecretPackage`].
+onto a [`round2::SecretPackage`].
 
 After the third part, each participant will get a [`KeyPackage`] with their
 long-term secret share that must be kept secret, and a [`PublicKeyPackage`]
@@ -53,7 +53,7 @@ let mut received_round1_packages = HashMap::new();
 // In practice, each participant will perform this on their own environments.
 for participant_index in 1..=max_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
-    let (secret_package, round1_package) = frost::keys::dkg::keygen_part1(
+    let (secret_package, round1_package) = frost::keys::dkg::part1(
         participant_identifier,
         max_signers,
         min_signers,
@@ -99,7 +99,7 @@ let mut received_round2_packages = HashMap::new();
 // In practice, each participant will perform this on their own environments.
 for participant_index in 1..=max_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
-    let (round2_secret_package, round2_packages) = frost::keys::dkg::keygen_part2(
+    let (round2_secret_package, round2_packages) = frost::keys::dkg::part2(
         round1_secret_packages
             .remove(&participant_identifier)
             .unwrap(),
@@ -142,7 +142,7 @@ let mut pubkey_packages = HashMap::new();
 // In practice, each participant will perform this on their own environments.
 for participant_index in 1..=max_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
-    let (key_package, pubkey_package_for_participant) = frost::keys::dkg::keygen_part3(
+    let (key_package, pubkey_package_for_participant) = frost::keys::dkg::part3(
         &round2_secret_packages[&participant_identifier],
         &received_round1_packages[&participant_identifier],
         &received_round2_packages[&participant_identifier],

--- a/frost-secp256k1/src/keys/dkg.rs
+++ b/frost-secp256k1/src/keys/dkg.rs
@@ -1,77 +1,87 @@
 #![doc = include_str!("../../dkg.md")]
 use super::*;
 
-/// The secret package that must be kept in memory by the participant
-/// between the first and second parts of the DKG protocol (round 1).
-///
-/// # Security
-///
-/// This package MUST NOT be sent to other participants!
-pub type Round1SecretPackage = frost::keys::dkg::Round1SecretPackage<S>;
+/// DKG Round 1 structures.
+pub mod round1 {
+    use super::*;
 
-/// The package that must be broadcast by each participant to all other participants
-/// between the first and second parts of the DKG protocol (round 1).
-pub type Round1Package = frost::keys::dkg::Round1Package<S>;
+    /// The secret package that must be kept in memory by the participant
+    /// between the first and second parts of the DKG protocol (round 1).
+    ///
+    /// # Security
+    ///
+    /// This package MUST NOT be sent to other participants!
+    pub type SecretPackage = frost::keys::dkg::round1::SecretPackage<S>;
 
-/// The secret package that must be kept in memory by the participant
-/// between the second and third parts of the DKG protocol (round 2).
-///
-/// # Security
-///
-/// This package MUST NOT be sent to other participants!
-pub type Round2SecretPackage = frost::keys::dkg::Round2SecretPackage<S>;
+    /// The package that must be broadcast by each participant to all other participants
+    /// between the first and second parts of the DKG protocol (round 1).
+    pub type Package = frost::keys::dkg::round1::Package<S>;
+}
 
-/// A package that must be sent by each participant to some other participants
-/// in Round 2 of the DKG protocol. Note that there is one specific package
-/// for each specific recipient, in contrast to Round 1.
-///
-/// # Security
-///
-/// The package must be sent on an *confidential* and *authenticated* channel.
-pub type Round2Package = frost::keys::dkg::Round2Package<S>;
+/// DKG Round 2 structures.
+pub mod round2 {
+    use super::*;
+
+    /// The secret package that must be kept in memory by the participant
+    /// between the second and third parts of the DKG protocol (round 2).
+    ///
+    /// # Security
+    ///
+    /// This package MUST NOT be sent to other participants!
+    pub type SecretPackage = frost::keys::dkg::round2::SecretPackage<S>;
+
+    /// A package that must be sent by each participant to some other participants
+    /// in Round 2 of the DKG protocol. Note that there is one specific package
+    /// for each specific recipient, in contrast to Round 1.
+    ///
+    /// # Security
+    ///
+    /// The package must be sent on an *confidential* and *authenticated* channel.
+    pub type Package = frost::keys::dkg::round2::Package<S>;
+}
 
 /// Performs the first part of the distributed key generation protocol
 /// for the given participant.
 ///
-/// It returns the [`Round1SecretPackage`] that must be kept in memory
-/// by the participant for the other steps, and the [`Round1Package`] that
+/// It returns the [`round1::SecretPackage`] that must be kept in memory
+/// by the participant for the other steps, and the [`round1::Package`] that
 /// must be sent to other participants.
-pub fn keygen_part1<R: RngCore + CryptoRng>(
+pub fn part1<R: RngCore + CryptoRng>(
     identifier: Identifier,
     max_signers: u16,
     min_signers: u16,
     mut rng: R,
-) -> Result<(Round1SecretPackage, Round1Package), Error> {
-    frost::keys::dkg::keygen_part1(identifier, max_signers, min_signers, &mut rng)
+) -> Result<(round1::SecretPackage, round1::Package), Error> {
+    frost::keys::dkg::part1(identifier, max_signers, min_signers, &mut rng)
 }
 
 /// Performs the second part of the distributed key generation protocol
-/// for the participant holding the given [`Round1SecretPackage`],
-/// given the received [`Round1Package`]s received from the other participants.
+/// for the participant holding the given [`round1::SecretPackage`],
+/// given the received [`round1::Package`]s received from the other participants.
 ///
-/// It returns the [`Round2SecretPackage`] that must be kept in memory
-/// by the participant for the final step, and the [`Round2Package`]s that
+/// It returns the [`round2::SecretPackage`] that must be kept in memory
+/// by the participant for the final step, and the [`round2::Package`]s that
 /// must be sent to other participants.
-pub fn keygen_part2(
-    secret_package: Round1SecretPackage,
-    round1_packages: &[Round1Package],
-) -> Result<(Round2SecretPackage, Vec<Round2Package>), Error> {
-    frost::keys::dkg::keygen_part2(secret_package, round1_packages)
+pub fn part2(
+    secret_package: round1::SecretPackage,
+    round1_packages: &[round1::Package],
+) -> Result<(round2::SecretPackage, Vec<round2::Package>), Error> {
+    frost::keys::dkg::part2(secret_package, round1_packages)
 }
 
 /// Performs the third and final part of the distributed key generation protocol
-/// for the participant holding the given [`Round2SecretPackage`],
-/// given the received [`Round1Package`]s and [`Round2Package`]s received from
+/// for the participant holding the given [`round2::SecretPackage`],
+/// given the received [`round1::Package`]s and [`round2::Package`]s received from
 /// the other participants.
 ///
 /// It returns the [`KeyPackage`] that has the long-lived key share for the
 /// participant, and the [`PublicKeyPackage`]s that has public information
 /// about all participants; both of which are required to compute FROST
 /// signatures.
-pub fn keygen_part3(
-    round2_secret_package: &Round2SecretPackage,
-    round1_packages: &[Round1Package],
-    round2_packages: &[Round2Package],
+pub fn part3(
+    round2_secret_package: &round2::SecretPackage,
+    round1_packages: &[round1::Package],
+    round2_packages: &[round2::Package],
 ) -> Result<(KeyPackage, PublicKeyPackage), Error> {
-    frost::keys::dkg::keygen_part3(round2_secret_package, round1_packages, round2_packages)
+    frost::keys::dkg::part3(round2_secret_package, round1_packages, round2_packages)
 }

--- a/gendoc/src/main.rs
+++ b/gendoc/src/main.rs
@@ -145,7 +145,6 @@ fn main() -> ExitCode {
     ];
 
     let docs = read_docs("frost-ristretto255/src/lib.rs", original_strings);
-    let dkg_docs = read_docs("frost-ristretto255/src/keys/dkg.rs", original_strings);
 
     // To add a new ciphersuite, just copy a tuple and replace the required strings.
     for (folder, replacement_strings) in [
@@ -197,15 +196,12 @@ fn main() -> ExitCode {
         ),
     ] {
         let lib_filename = format!("{folder}/src/lib.rs");
-        let dkg_filename = format!("{folder}/src/keys/dkg.rs");
         // Copy the documentation of public items in Rust code, replacing ciphersuite-specific strings inside
         // them in the process.
-        for (docs, filename) in [(&docs, lib_filename), (&dkg_docs, dkg_filename)] {
-            replaced |= write_docs(docs, &filename, original_strings, replacement_strings);
-        }
-        // Copy Markdown documentation, replacing ciphersuite-specific strings inside
-        // them in the process.
-        for filename in ["README.md", "dkg.md"] {
+        replaced |= write_docs(&docs, &lib_filename, original_strings, replacement_strings);
+
+        // Generate files based on a template with simple search & replace.
+        for filename in ["README.md", "dkg.md", "src/keys/dkg.rs"] {
             replaced |= copy_and_replace(
                 format!("{original_folder}/{filename}").as_str(),
                 format!("{folder}/{filename}").as_str(),


### PR DESCRIPTION
Closes #255 

Since `dkg.rs` are very similar between crates (just the ciphersuite "letter" changes, e.g. `<E>` or `<R>`), I changed `gendoc` to use the naive search & replace to generate the whole file for all ciphersuites instead of just copying the canonical documentation (which would require refactoring the functions in all files). At this point it should be called "gencode" or something but we can do that in a separate PR.