### PR TITLE
move comment to make gencode work

### DIFF
--- a/frost-ed25519/src/lib.rs
+++ b/frost-ed25519/src/lib.rs
@@ -19,8 +19,8 @@ mod tests;
 /// An error.
 pub type Error = frost_core::Error<Ed25519Sha512>;
 
-/// An implementation of the FROST(Ed25519, SHA-512) ciphersuite scalar field.
 #[derive(Clone, Copy)]
+/// An implementation of the FROST(Ed25519, SHA-512) ciphersuite scalar field.
 pub struct Ed25519ScalarField;
 
 impl Field for Ed25519ScalarField {


### PR DESCRIPTION
`gencode` does not currently support the documentation not being directly the declaration (i.e. before `#[derive]s`).

A comment was moved in one of the files which was making  `gencode` fail. This fixes that.

The proper fix is #227 