### PR TITLE
Re-export the frost-core traits and rand-core as part of top-level impls API

### DIFF
--- a/frost-ed25519/src/lib.rs
+++ b/frost-ed25519/src/lib.rs
@@ -11,10 +11,14 @@ use curve25519_dalek::{
 use rand_core::{CryptoRng, RngCore};
 use sha2::{Digest, Sha512};
 
-use frost_core::{frost, Ciphersuite, Field, FieldError, Group, GroupError};
+pub use frost_core::frost;
 
 #[cfg(test)]
 mod tests;
+
+// Re-exports in our public API
+pub use frost_core::{Ciphersuite, Field, FieldError, Group, GroupError};
+pub use rand_core;
 
 /// An error.
 pub type Error = frost_core::Error<Ed25519Sha512>;

--- a/frost-ed25519/src/lib.rs
+++ b/frost-ed25519/src/lib.rs
@@ -11,7 +11,7 @@ use curve25519_dalek::{
 use rand_core::{CryptoRng, RngCore};
 use sha2::{Digest, Sha512};
 
-pub use frost_core::frost;
+use frost_core::frost;
 
 #[cfg(test)]
 mod tests;

--- a/frost-ed25519/tests/frost.rs
+++ b/frost-ed25519/tests/frost.rs
@@ -1,4 +1,3 @@
-use frost_core::{Ciphersuite, Group, GroupError};
 use frost_ed25519::*;
 
 use curve25519_dalek::{edwards::EdwardsPoint, traits::Identity};

--- a/frost-ed448/src/lib.rs
+++ b/frost-ed448/src/lib.rs
@@ -12,10 +12,14 @@ use sha3::{
     Shake256,
 };
 
-use frost_core::{frost, Ciphersuite, Field, FieldError, Group, GroupError};
+use frost_core::frost;
 
 #[cfg(test)]
 mod tests;
+
+// Re-exports in our public API
+pub use frost_core::{Ciphersuite, Field, FieldError, Group, GroupError};
+pub use rand_core;
 
 /// An error.
 pub type Error = frost_core::Error<Ed448Shake256>;

--- a/frost-ed448/tests/frost.rs
+++ b/frost-ed448/tests/frost.rs
@@ -1,5 +1,5 @@
 use ed448_goldilocks::curve::ExtendedPoint;
-use frost_core::{Ciphersuite, Group, GroupError};
+
 use frost_ed448::*;
 use rand::thread_rng;
 

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -13,10 +13,14 @@ use p256::{
 use rand_core::{CryptoRng, RngCore};
 use sha2::{Digest, Sha256};
 
-use frost_core::{frost, Ciphersuite, Field, FieldError, Group, GroupError};
+use frost_core::frost;
 
 #[cfg(test)]
 mod tests;
+
+// Re-exports in our public API
+pub use frost_core::{Ciphersuite, Field, FieldError, Group, GroupError};
+pub use rand_core;
 
 /// An error.
 pub type Error = frost_core::Error<P256Sha256>;

--- a/frost-p256/tests/frost.rs
+++ b/frost-p256/tests/frost.rs
@@ -1,4 +1,3 @@
-use frost_core::{Ciphersuite, Group, GroupError};
 use frost_p256::*;
 use rand::thread_rng;
 

--- a/frost-rerandomized/src/lib.rs
+++ b/frost-rerandomized/src/lib.rs
@@ -12,6 +12,8 @@ use frost_core::{
     Ciphersuite, Error, Field, Group, VerifyingKey,
 };
 
+// When pulled into `reddsa`, that has its own sibling `rand_core` import.
+// For the time being, we do not re-export this `rand_core`.
 use rand_core::{CryptoRng, RngCore};
 
 /// Performed once by each participant selected for the signing operation.

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -11,10 +11,14 @@ use curve25519_dalek::{
 use rand_core::{CryptoRng, RngCore};
 use sha2::{Digest, Sha512};
 
-use frost_core::{frost, Ciphersuite, Field, FieldError, Group, GroupError};
+pub use frost_core::frost;
 
 #[cfg(test)]
 mod tests;
+
+// Re-exports in our public API
+pub use frost_core::{Ciphersuite, Field, FieldError, Group, GroupError};
+pub use rand_core;
 
 /// An error.
 pub type Error = frost_core::Error<Ristretto255Sha512>;

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -11,7 +11,7 @@ use curve25519_dalek::{
 use rand_core::{CryptoRng, RngCore};
 use sha2::{Digest, Sha512};
 
-pub use frost_core::frost;
+use frost_core::frost;
 
 #[cfg(test)]
 mod tests;

--- a/frost-ristretto255/tests/frost.rs
+++ b/frost-ristretto255/tests/frost.rs
@@ -1,5 +1,4 @@
 use curve25519_dalek::{ristretto::RistrettoPoint, traits::Identity};
-use frost_core::{Ciphersuite, Group, GroupError};
 use frost_ristretto255::*;
 use rand::thread_rng;
 

--- a/frost-secp256k1/src/lib.rs
+++ b/frost-secp256k1/src/lib.rs
@@ -14,10 +14,14 @@ use k256::{
 use rand_core::{CryptoRng, RngCore};
 use sha2::{Digest, Sha256};
 
-use frost_core::{frost, Ciphersuite, Field, FieldError, Group, GroupError};
+use frost_core::frost;
 
 #[cfg(test)]
 mod tests;
+
+// Re-exports in our public API
+pub use frost_core::{Ciphersuite, Field, FieldError, Group, GroupError};
+pub use rand_core;
 
 /// An error.
 pub type Error = frost_core::Error<Secp256K1Sha256>;

--- a/frost-secp256k1/tests/frost.rs
+++ b/frost-secp256k1/tests/frost.rs
@@ -1,4 +1,3 @@
-use frost_core::{Ciphersuite, Group, GroupError};
 use frost_secp256k1::*;
 use rand::thread_rng;
 


### PR DESCRIPTION
Resolves #296 