### PR TITLE
implement Zeroize where needed or skip where not needed

### DIFF
--- a/frost-core/src/frost/keys.rs
+++ b/frost-core/src/frost/keys.rs
@@ -261,9 +261,11 @@ pub struct VerifiableSecretSharingCommitment<C: Ciphersuite>(
 #[derive(Clone, Zeroize)]
 pub struct SecretShare<C: Ciphersuite> {
     /// The participant identifier of this [`SecretShare`].
+    #[zeroize(skip)]
     pub identifier: Identifier<C>,
     /// Secret Key.
     pub value: SigningShare<C>,
+    #[zeroize(skip)]
     /// The commitments to be distributed among signers.
     pub commitment: VerifiableSecretSharingCommitment<C>,
 }

--- a/frost-core/src/frost/round1.rs
+++ b/frost-core/src/frost/round1.rs
@@ -13,7 +13,7 @@ use crate::{frost, Ciphersuite, Element, Error, Field, Group, Scalar};
 use super::{keys::SigningShare, Identifier};
 
 /// A scalar that is a signing nonce.
-#[derive(Clone, PartialEq, Eq, Zeroize)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Nonce<C: Ciphersuite>(pub(super) Scalar<C>);
 
 impl<C> Nonce<C>
@@ -68,6 +68,15 @@ where
     /// Serialize [`Nonce`] to bytes
     pub fn to_bytes(&self) -> <<C::Group as Group>::Field as Field>::Serialization {
         <<C::Group as Group>::Field>::serialize(&self.0)
+    }
+}
+
+impl<C> Zeroize for Nonce<C>
+where
+    C: Ciphersuite,
+{
+    fn zeroize(&mut self) {
+        *self = Nonce(<<C::Group as Group>::Field>::zero());
     }
 }
 


### PR DESCRIPTION
Closes #294 

It seems that we were missing some `Zeroize` implementations. Which is weird, since it worked before (`zeroze_derive` < 1.4.0). This could indicate a bug in `zeroize_derive` that was accepting things that shouldn't be accepted? I'll investigate further and will try to create a smaller reproducible code, but in the meantime we can fix the build issue.