### PR TITLE
Don't run docs publish workflow when cargo files updated

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,13 +18,6 @@ on:
       - 'book/**'
       - '**/firebase.json'
       - 'katex-header.html'
-      # rustdoc source files
-      - '**/*.rs'
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      # configuration files
-      - '.cargo/config.toml'
-      - '**/clippy.toml'
       # workflow definitions
       - '.github/workflows/docs.yml'
 


### PR DESCRIPTION
We're not publishing rustdoc with this flow, just the book