### PR TITLE
Change gencode to handle repairable module; fix build issues

### DIFF
--- a/frost-ed25519/src/keys/repairable.rs
+++ b/frost-ed25519/src/keys/repairable.rs
@@ -6,7 +6,11 @@
 
 use std::collections::HashMap;
 
-use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, R};
+// This is imported separately to make `gencode` work.
+// (if it were below, the position of the import would vary between ciphersuites
+//  after `cargo fmt`)
+use crate::Ed25519Sha512;
+use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar};
 
 use super::{SecretShare, VerifiableSecretSharingCommitment};
 
@@ -34,7 +38,7 @@ pub fn repair_share_step_1<C: Ciphersuite, R: RngCore + CryptoRng>(
 ///
 /// Returns a scalar
 pub fn repair_share_step_2(deltas_j: &[Scalar]) -> Scalar {
-    frost::keys::repairable::repair_share_step_2::<E>(deltas_j)
+    frost::keys::repairable::repair_share_step_2::<Ed25519Sha512>(deltas_j)
 }
 
 /// Step 3 of RTS

--- a/frost-ed25519/src/keys/repairable.rs
+++ b/frost-ed25519/src/keys/repairable.rs
@@ -1,15 +1,19 @@
-/// Repairable Threshold Scheme
-
+/// Repairable Threshold Schemes
 #![doc = include_str!("../../repairable.md")]
 
 use std::collections::HashMap;
 
 use crate::{frost::Identifier, Ciphersuite, CryptoRng, Field, Group, RngCore, Scalar};
 
-use super::{SecretShare};
+use super::SecretShare;
 
-/// Generate random values for each helper - 1 for use in computing the value for the final helper
-
+/// Step 1 of RTS.
+///
+/// Generates the "delta" values from `helper_i` to help `participant` recover their share
+/// where `helpers` contains the identifiers of all the helpers (including `helper_i`), and `share_i`
+/// is the share of `helper_i`.
+///
+/// Returns a HashMap mapping which value should be sent to which participant.
 pub fn repair_share_step_1<R: RngCore + CryptoRng>(
     helpers: &[Identifier<C>],
     share_i: &SecretShare<C>,
@@ -19,22 +23,22 @@ pub fn repair_share_step_1<R: RngCore + CryptoRng>(
     frost::keys::repairable::repair_share_step_1(identifier, max_signers, min_signers, &mut rng)
 }
 
-/// # Communication round:
-/// # Helper i sends deltas_i[j] to helper j
-
-/// # deltas_j: values received by j in the communication round
-/// # Output: sigma_j
-
+/// Step 3 of RTS.
+///
+/// Generates the `sigma` values from all `deltas` received from `helpers`
+/// to help `participant` recover their share.
+/// `sigma` is the sum of all received `delta` and the `delta_i` generated for `helper_i`.
+///
+/// Returns a scalar
 pub fn repair_share_step_2<C: Ciphersuite>(deltas_j: &[Scalar<C>]) -> Scalar<C> {
     frost::keys::repairable::repair_share_step_2(deltas_j)
 }
 
-/// # Communication round
-/// # Helper j sends sigma_j to signer r
-
-/// # sigmas: all sigma_j received from each helper j
-/// # Output: share_r: r's secret share
-
+/// Step 5 of RTS
+///
+/// The `participant` sums all `sigma_j` received to compute the `share`. The `SecretShare`
+/// is made up of the `identifier`and `commitment` of the `participant` as well as the
+/// `value` which is the `SigningShare`.
 pub fn repair_share_step_3<C: Ciphersuite>(
     sigmas: &[Scalar<C>],
     identifier: Identifier<C>,

--- a/frost-ed25519/src/keys/repairable.rs
+++ b/frost-ed25519/src/keys/repairable.rs
@@ -1,8 +1,12 @@
-//! Repairable Threshold Schemes
+//! Repairable Threshold Scheme
+//!
+//! Implements the Repairable Threshold Scheme (RTS) from <https://eprint.iacr.org/2017/1155>.
+//! The RTS is used to help a signer (participant) repair their lost share. This is achieved
+//! using a subset of the other signers know here as `helpers`.
 
 use std::collections::HashMap;
 
-use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, E};
+use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, R};
 
 use super::{SecretShare, VerifiableSecretSharingCommitment};
 

--- a/frost-ed25519/src/keys/repairable.rs
+++ b/frost-ed25519/src/keys/repairable.rs
@@ -1,11 +1,10 @@
-/// Repairable Threshold Schemes
-#![doc = include_str!("../../repairable.md")]
+//! Repairable Threshold Schemes
 
 use std::collections::HashMap;
 
-use crate::{frost::Identifier, Ciphersuite, CryptoRng, Field, Group, RngCore, Scalar};
+use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, E};
 
-use super::SecretShare;
+use super::{SecretShare, VerifiableSecretSharingCommitment};
 
 /// Step 1 of RTS.
 ///
@@ -14,35 +13,35 @@ use super::SecretShare;
 /// is the share of `helper_i`.
 ///
 /// Returns a HashMap mapping which value should be sent to which participant.
-pub fn repair_share_step_1<R: RngCore + CryptoRng>(
-    helpers: &[Identifier<C>],
-    share_i: &SecretShare<C>,
-    zeta_i: Scalar<C>,
+pub fn repair_share_step_1<C: Ciphersuite, R: RngCore + CryptoRng>(
+    helpers: &[Identifier],
+    share_i: &SecretShare,
     rng: &mut R,
-) -> HashMap<Identifier<C>, Scalar<C>> {
-    frost::keys::repairable::repair_share_step_1(identifier, max_signers, min_signers, &mut rng)
+    participant: Identifier,
+) -> HashMap<Identifier, Scalar> {
+    frost::keys::repairable::repair_share_step_1(helpers, share_i, rng, participant)
 }
 
-/// Step 3 of RTS.
+/// Step 2 of RTS.
 ///
 /// Generates the `sigma` values from all `deltas` received from `helpers`
 /// to help `participant` recover their share.
 /// `sigma` is the sum of all received `delta` and the `delta_i` generated for `helper_i`.
 ///
 /// Returns a scalar
-pub fn repair_share_step_2<C: Ciphersuite>(deltas_j: &[Scalar<C>]) -> Scalar<C> {
-    frost::keys::repairable::repair_share_step_2(deltas_j)
+pub fn repair_share_step_2(deltas_j: &[Scalar]) -> Scalar {
+    frost::keys::repairable::repair_share_step_2::<E>(deltas_j)
 }
 
-/// Step 5 of RTS
+/// Step 3 of RTS
 ///
 /// The `participant` sums all `sigma_j` received to compute the `share`. The `SecretShare`
 /// is made up of the `identifier`and `commitment` of the `participant` as well as the
 /// `value` which is the `SigningShare`.
-pub fn repair_share_step_3<C: Ciphersuite>(
-    sigmas: &[Scalar<C>],
-    identifier: Identifier<C>,
-    commitment: &VerifiableSecretSharingCommitment<C>,
-) -> SecretShare<C> {
-    frost::keys::repairable::repair_share(sigmas, identifier, commitment)
+pub fn repair_share_step_3(
+    sigmas: &[Scalar],
+    identifier: Identifier,
+    commitment: &VerifiableSecretSharingCommitment,
+) -> SecretShare {
+    frost::keys::repairable::repair_share_step_3(sigmas, identifier, commitment)
 }

--- a/frost-ed25519/src/lib.rs
+++ b/frost-ed25519/src/lib.rs
@@ -241,7 +241,22 @@ pub mod keys {
     /// Used for verification purposes before publishing a signature.
     pub type PublicKeyPackage = frost::keys::PublicKeyPackage<E>;
 
+    /// Contains the commitments to the coefficients for our secret polynomial _f_,
+    /// used to generate participants' key shares.
+    ///
+    /// [`VerifiableSecretSharingCommitment`] contains a set of commitments to the coefficients (which
+    /// themselves are scalars) for a secret polynomial f, where f is used to
+    /// generate each ith participant's key share f(i). Participants use this set of
+    /// commitments to perform verifiable secret sharing.
+    ///
+    /// Note that participants MUST be assured that they have the *same*
+    /// [`VerifiableSecretSharingCommitment`], either by performing pairwise comparison, or by using
+    /// some agreed-upon public location for publication, where each participant can
+    /// ensure that they received the correct (and same) value.
+    pub type VerifiableSecretSharingCommitment = frost::keys::VerifiableSecretSharingCommitment<E>;
+
     pub mod dkg;
+    pub mod repairable;
 }
 
 /// FROST(Ed25519, SHA-512) Round 1 functionality and types.

--- a/frost-ed448/src/keys/repairable.rs
+++ b/frost-ed448/src/keys/repairable.rs
@@ -1,15 +1,19 @@
-/// Repairable Threshold Scheme
-
+/// Repairable Threshold Schemes
 #![doc = include_str!("../../repairable.md")]
 
 use std::collections::HashMap;
 
 use crate::{frost::Identifier, Ciphersuite, CryptoRng, Field, Group, RngCore, Scalar};
 
-use super::{SecretShare};
+use super::SecretShare;
 
-/// Generate random values for each helper - 1 for use in computing the value for the final helper
-
+/// Step 1 of RTS.
+///
+/// Generates the "delta" values from `helper_i` to help `participant` recover their share
+/// where `helpers` contains the identifiers of all the helpers (including `helper_i`), and `share_i`
+/// is the share of `helper_i`.
+///
+/// Returns a HashMap mapping which value should be sent to which participant.
 pub fn repair_share_step_1<R: RngCore + CryptoRng>(
     helpers: &[Identifier<C>],
     share_i: &SecretShare<C>,
@@ -19,22 +23,22 @@ pub fn repair_share_step_1<R: RngCore + CryptoRng>(
     frost::keys::repairable::repair_share_step_1(identifier, max_signers, min_signers, &mut rng)
 }
 
-/// # Communication round:
-/// # Helper i sends deltas_i[j] to helper j
-
-/// # deltas_j: values received by j in the communication round
-/// # Output: sigma_j
-
+/// Step 3 of RTS.
+///
+/// Generates the `sigma` values from all `deltas` received from `helpers`
+/// to help `participant` recover their share.
+/// `sigma` is the sum of all received `delta` and the `delta_i` generated for `helper_i`.
+///
+/// Returns a scalar
 pub fn repair_share_step_2<C: Ciphersuite>(deltas_j: &[Scalar<C>]) -> Scalar<C> {
     frost::keys::repairable::repair_share_step_2(deltas_j)
 }
 
-/// # Communication round
-/// # Helper j sends sigma_j to signer r
-
-/// # sigmas: all sigma_j received from each helper j
-/// # Output: share_r: r's secret share
-
+/// Step 5 of RTS
+///
+/// The `participant` sums all `sigma_j` received to compute the `share`. The `SecretShare`
+/// is made up of the `identifier`and `commitment` of the `participant` as well as the
+/// `value` which is the `SigningShare`.
 pub fn repair_share_step_3<C: Ciphersuite>(
     sigmas: &[Scalar<C>],
     identifier: Identifier<C>,

--- a/frost-ed448/src/keys/repairable.rs
+++ b/frost-ed448/src/keys/repairable.rs
@@ -1,8 +1,12 @@
-//! Repairable Threshold Schemes
+//! Repairable Threshold Scheme
+//!
+//! Implements the Repairable Threshold Scheme (RTS) from <https://eprint.iacr.org/2017/1155>.
+//! The RTS is used to help a signer (participant) repair their lost share. This is achieved
+//! using a subset of the other signers know here as `helpers`.
 
 use std::collections::HashMap;
 
-use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, E};
+use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, R};
 
 use super::{SecretShare, VerifiableSecretSharingCommitment};
 

--- a/frost-ed448/src/keys/repairable.rs
+++ b/frost-ed448/src/keys/repairable.rs
@@ -6,7 +6,11 @@
 
 use std::collections::HashMap;
 
-use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, R};
+// This is imported separately to make `gencode` work.
+// (if it were below, the position of the import would vary between ciphersuites
+//  after `cargo fmt`)
+use crate::Ed448Shake256;
+use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar};
 
 use super::{SecretShare, VerifiableSecretSharingCommitment};
 
@@ -34,7 +38,7 @@ pub fn repair_share_step_1<C: Ciphersuite, R: RngCore + CryptoRng>(
 ///
 /// Returns a scalar
 pub fn repair_share_step_2(deltas_j: &[Scalar]) -> Scalar {
-    frost::keys::repairable::repair_share_step_2::<E>(deltas_j)
+    frost::keys::repairable::repair_share_step_2::<Ed448Shake256>(deltas_j)
 }
 
 /// Step 3 of RTS

--- a/frost-ed448/src/keys/repairable.rs
+++ b/frost-ed448/src/keys/repairable.rs
@@ -1,11 +1,10 @@
-/// Repairable Threshold Schemes
-#![doc = include_str!("../../repairable.md")]
+//! Repairable Threshold Schemes
 
 use std::collections::HashMap;
 
-use crate::{frost::Identifier, Ciphersuite, CryptoRng, Field, Group, RngCore, Scalar};
+use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, E};
 
-use super::SecretShare;
+use super::{SecretShare, VerifiableSecretSharingCommitment};
 
 /// Step 1 of RTS.
 ///
@@ -14,35 +13,35 @@ use super::SecretShare;
 /// is the share of `helper_i`.
 ///
 /// Returns a HashMap mapping which value should be sent to which participant.
-pub fn repair_share_step_1<R: RngCore + CryptoRng>(
-    helpers: &[Identifier<C>],
-    share_i: &SecretShare<C>,
-    zeta_i: Scalar<C>,
+pub fn repair_share_step_1<C: Ciphersuite, R: RngCore + CryptoRng>(
+    helpers: &[Identifier],
+    share_i: &SecretShare,
     rng: &mut R,
-) -> HashMap<Identifier<C>, Scalar<C>> {
-    frost::keys::repairable::repair_share_step_1(identifier, max_signers, min_signers, &mut rng)
+    participant: Identifier,
+) -> HashMap<Identifier, Scalar> {
+    frost::keys::repairable::repair_share_step_1(helpers, share_i, rng, participant)
 }
 
-/// Step 3 of RTS.
+/// Step 2 of RTS.
 ///
 /// Generates the `sigma` values from all `deltas` received from `helpers`
 /// to help `participant` recover their share.
 /// `sigma` is the sum of all received `delta` and the `delta_i` generated for `helper_i`.
 ///
 /// Returns a scalar
-pub fn repair_share_step_2<C: Ciphersuite>(deltas_j: &[Scalar<C>]) -> Scalar<C> {
-    frost::keys::repairable::repair_share_step_2(deltas_j)
+pub fn repair_share_step_2(deltas_j: &[Scalar]) -> Scalar {
+    frost::keys::repairable::repair_share_step_2::<E>(deltas_j)
 }
 
-/// Step 5 of RTS
+/// Step 3 of RTS
 ///
 /// The `participant` sums all `sigma_j` received to compute the `share`. The `SecretShare`
 /// is made up of the `identifier`and `commitment` of the `participant` as well as the
 /// `value` which is the `SigningShare`.
-pub fn repair_share_step_3<C: Ciphersuite>(
-    sigmas: &[Scalar<C>],
-    identifier: Identifier<C>,
-    commitment: &VerifiableSecretSharingCommitment<C>,
-) -> SecretShare<C> {
-    frost::keys::repairable::repair_share(sigmas, identifier, commitment)
+pub fn repair_share_step_3(
+    sigmas: &[Scalar],
+    identifier: Identifier,
+    commitment: &VerifiableSecretSharingCommitment,
+) -> SecretShare {
+    frost::keys::repairable::repair_share_step_3(sigmas, identifier, commitment)
 }

--- a/frost-ed448/src/lib.rs
+++ b/frost-ed448/src/lib.rs
@@ -235,7 +235,22 @@ pub mod keys {
     /// Used for verification purposes before publishing a signature.
     pub type PublicKeyPackage = frost::keys::PublicKeyPackage<E>;
 
+    /// Contains the commitments to the coefficients for our secret polynomial _f_,
+    /// used to generate participants' key shares.
+    ///
+    /// [`VerifiableSecretSharingCommitment`] contains a set of commitments to the coefficients (which
+    /// themselves are scalars) for a secret polynomial f, where f is used to
+    /// generate each ith participant's key share f(i). Participants use this set of
+    /// commitments to perform verifiable secret sharing.
+    ///
+    /// Note that participants MUST be assured that they have the *same*
+    /// [`VerifiableSecretSharingCommitment`], either by performing pairwise comparison, or by using
+    /// some agreed-upon public location for publication, where each participant can
+    /// ensure that they received the correct (and same) value.
+    pub type VerifiableSecretSharingCommitment = frost::keys::VerifiableSecretSharingCommitment<E>;
+
     pub mod dkg;
+    pub mod repairable;
 }
 
 /// FROST(Ed448, SHAKE256) Round 1 functionality and types.

--- a/frost-p256/src/keys/repairable.rs
+++ b/frost-p256/src/keys/repairable.rs
@@ -1,15 +1,19 @@
-/// Repairable Threshold Scheme
-
+/// Repairable Threshold Schemes
 #![doc = include_str!("../../repairable.md")]
 
 use std::collections::HashMap;
 
 use crate::{frost::Identifier, Ciphersuite, CryptoRng, Field, Group, RngCore, Scalar};
 
-use super::{SecretShare};
+use super::SecretShare;
 
-/// Generate random values for each helper - 1 for use in computing the value for the final helper
-
+/// Step 1 of RTS.
+///
+/// Generates the "delta" values from `helper_i` to help `participant` recover their share
+/// where `helpers` contains the identifiers of all the helpers (including `helper_i`), and `share_i`
+/// is the share of `helper_i`.
+///
+/// Returns a HashMap mapping which value should be sent to which participant.
 pub fn repair_share_step_1<R: RngCore + CryptoRng>(
     helpers: &[Identifier<C>],
     share_i: &SecretShare<C>,
@@ -19,22 +23,22 @@ pub fn repair_share_step_1<R: RngCore + CryptoRng>(
     frost::keys::repairable::repair_share_step_1(identifier, max_signers, min_signers, &mut rng)
 }
 
-/// # Communication round:
-/// # Helper i sends deltas_i[j] to helper j
-
-/// # deltas_j: values received by j in the communication round
-/// # Output: sigma_j
-
+/// Step 3 of RTS.
+///
+/// Generates the `sigma` values from all `deltas` received from `helpers`
+/// to help `participant` recover their share.
+/// `sigma` is the sum of all received `delta` and the `delta_i` generated for `helper_i`.
+///
+/// Returns a scalar
 pub fn repair_share_step_2<C: Ciphersuite>(deltas_j: &[Scalar<C>]) -> Scalar<C> {
     frost::keys::repairable::repair_share_step_2(deltas_j)
 }
 
-/// # Communication round
-/// # Helper j sends sigma_j to signer r
-
-/// # sigmas: all sigma_j received from each helper j
-/// # Output: share_r: r's secret share
-
+/// Step 5 of RTS
+///
+/// The `participant` sums all `sigma_j` received to compute the `share`. The `SecretShare`
+/// is made up of the `identifier`and `commitment` of the `participant` as well as the
+/// `value` which is the `SigningShare`.
 pub fn repair_share_step_3<C: Ciphersuite>(
     sigmas: &[Scalar<C>],
     identifier: Identifier<C>,

--- a/frost-p256/src/keys/repairable.rs
+++ b/frost-p256/src/keys/repairable.rs
@@ -1,8 +1,12 @@
-//! Repairable Threshold Schemes
+//! Repairable Threshold Scheme
+//!
+//! Implements the Repairable Threshold Scheme (RTS) from <https://eprint.iacr.org/2017/1155>.
+//! The RTS is used to help a signer (participant) repair their lost share. This is achieved
+//! using a subset of the other signers know here as `helpers`.
 
 use std::collections::HashMap;
 
-use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, P};
+use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, R};
 
 use super::{SecretShare, VerifiableSecretSharingCommitment};
 

--- a/frost-p256/src/keys/repairable.rs
+++ b/frost-p256/src/keys/repairable.rs
@@ -1,11 +1,10 @@
-/// Repairable Threshold Schemes
-#![doc = include_str!("../../repairable.md")]
+//! Repairable Threshold Schemes
 
 use std::collections::HashMap;
 
-use crate::{frost::Identifier, Ciphersuite, CryptoRng, Field, Group, RngCore, Scalar};
+use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, P};
 
-use super::SecretShare;
+use super::{SecretShare, VerifiableSecretSharingCommitment};
 
 /// Step 1 of RTS.
 ///
@@ -14,35 +13,35 @@ use super::SecretShare;
 /// is the share of `helper_i`.
 ///
 /// Returns a HashMap mapping which value should be sent to which participant.
-pub fn repair_share_step_1<R: RngCore + CryptoRng>(
-    helpers: &[Identifier<C>],
-    share_i: &SecretShare<C>,
-    zeta_i: Scalar<C>,
+pub fn repair_share_step_1<C: Ciphersuite, R: RngCore + CryptoRng>(
+    helpers: &[Identifier],
+    share_i: &SecretShare,
     rng: &mut R,
-) -> HashMap<Identifier<C>, Scalar<C>> {
-    frost::keys::repairable::repair_share_step_1(identifier, max_signers, min_signers, &mut rng)
+    participant: Identifier,
+) -> HashMap<Identifier, Scalar> {
+    frost::keys::repairable::repair_share_step_1(helpers, share_i, rng, participant)
 }
 
-/// Step 3 of RTS.
+/// Step 2 of RTS.
 ///
 /// Generates the `sigma` values from all `deltas` received from `helpers`
 /// to help `participant` recover their share.
 /// `sigma` is the sum of all received `delta` and the `delta_i` generated for `helper_i`.
 ///
 /// Returns a scalar
-pub fn repair_share_step_2<C: Ciphersuite>(deltas_j: &[Scalar<C>]) -> Scalar<C> {
-    frost::keys::repairable::repair_share_step_2(deltas_j)
+pub fn repair_share_step_2(deltas_j: &[Scalar]) -> Scalar {
+    frost::keys::repairable::repair_share_step_2::<P>(deltas_j)
 }
 
-/// Step 5 of RTS
+/// Step 3 of RTS
 ///
 /// The `participant` sums all `sigma_j` received to compute the `share`. The `SecretShare`
 /// is made up of the `identifier`and `commitment` of the `participant` as well as the
 /// `value` which is the `SigningShare`.
-pub fn repair_share_step_3<C: Ciphersuite>(
-    sigmas: &[Scalar<C>],
-    identifier: Identifier<C>,
-    commitment: &VerifiableSecretSharingCommitment<C>,
-) -> SecretShare<C> {
-    frost::keys::repairable::repair_share(sigmas, identifier, commitment)
+pub fn repair_share_step_3(
+    sigmas: &[Scalar],
+    identifier: Identifier,
+    commitment: &VerifiableSecretSharingCommitment,
+) -> SecretShare {
+    frost::keys::repairable::repair_share_step_3(sigmas, identifier, commitment)
 }

--- a/frost-p256/src/keys/repairable.rs
+++ b/frost-p256/src/keys/repairable.rs
@@ -6,7 +6,11 @@
 
 use std::collections::HashMap;
 
-use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, R};
+// This is imported separately to make `gencode` work.
+// (if it were below, the position of the import would vary between ciphersuites
+//  after `cargo fmt`)
+use crate::P256Sha256;
+use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar};
 
 use super::{SecretShare, VerifiableSecretSharingCommitment};
 
@@ -34,7 +38,7 @@ pub fn repair_share_step_1<C: Ciphersuite, R: RngCore + CryptoRng>(
 ///
 /// Returns a scalar
 pub fn repair_share_step_2(deltas_j: &[Scalar]) -> Scalar {
-    frost::keys::repairable::repair_share_step_2::<P>(deltas_j)
+    frost::keys::repairable::repair_share_step_2::<P256Sha256>(deltas_j)
 }
 
 /// Step 3 of RTS

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -265,7 +265,22 @@ pub mod keys {
     /// Used for verification purposes before publishing a signature.
     pub type PublicKeyPackage = frost::keys::PublicKeyPackage<P>;
 
+    /// Contains the commitments to the coefficients for our secret polynomial _f_,
+    /// used to generate participants' key shares.
+    ///
+    /// [`VerifiableSecretSharingCommitment`] contains a set of commitments to the coefficients (which
+    /// themselves are scalars) for a secret polynomial f, where f is used to
+    /// generate each ith participant's key share f(i). Participants use this set of
+    /// commitments to perform verifiable secret sharing.
+    ///
+    /// Note that participants MUST be assured that they have the *same*
+    /// [`VerifiableSecretSharingCommitment`], either by performing pairwise comparison, or by using
+    /// some agreed-upon public location for publication, where each participant can
+    /// ensure that they received the correct (and same) value.
+    pub type VerifiableSecretSharingCommitment = frost::keys::VerifiableSecretSharingCommitment<P>;
+
     pub mod dkg;
+    pub mod repairable;
 }
 
 /// FROST(P-256, SHA-256) Round 1 functionality and types.

--- a/frost-ristretto255/src/keys/repairable.rs
+++ b/frost-ristretto255/src/keys/repairable.rs
@@ -1,15 +1,19 @@
-/// Repairable Threshold Scheme
-
+/// Repairable Threshold Schemes
 #![doc = include_str!("../../repairable.md")]
 
 use std::collections::HashMap;
 
 use crate::{frost::Identifier, Ciphersuite, CryptoRng, Field, Group, RngCore, Scalar};
 
-use super::{SecretShare};
+use super::SecretShare;
 
-/// Generate random values for each helper - 1 for use in computing the value for the final helper
-
+/// Step 1 of RTS.
+///
+/// Generates the "delta" values from `helper_i` to help `participant` recover their share
+/// where `helpers` contains the identifiers of all the helpers (including `helper_i`), and `share_i`
+/// is the share of `helper_i`.
+///
+/// Returns a HashMap mapping which value should be sent to which participant.
 pub fn repair_share_step_1<R: RngCore + CryptoRng>(
     helpers: &[Identifier<C>],
     share_i: &SecretShare<C>,
@@ -19,22 +23,22 @@ pub fn repair_share_step_1<R: RngCore + CryptoRng>(
     frost::keys::repairable::repair_share_step_1(identifier, max_signers, min_signers, &mut rng)
 }
 
-/// # Communication round:
-/// # Helper i sends deltas_i[j] to helper j
-
-/// # deltas_j: values received by j in the communication round
-/// # Output: sigma_j
-
+/// Step 3 of RTS.
+///
+/// Generates the `sigma` values from all `deltas` received from `helpers`
+/// to help `participant` recover their share.
+/// `sigma` is the sum of all received `delta` and the `delta_i` generated for `helper_i`.
+///
+/// Returns a scalar
 pub fn repair_share_step_2<C: Ciphersuite>(deltas_j: &[Scalar<C>]) -> Scalar<C> {
     frost::keys::repairable::repair_share_step_2(deltas_j)
 }
 
-/// # Communication round
-/// # Helper j sends sigma_j to signer r
-
-/// # sigmas: all sigma_j received from each helper j
-/// # Output: share_r: r's secret share
-
+/// Step 5 of RTS
+///
+/// The `participant` sums all `sigma_j` received to compute the `share`. The `SecretShare`
+/// is made up of the `identifier`and `commitment` of the `participant` as well as the
+/// `value` which is the `SigningShare`.
 pub fn repair_share_step_3<C: Ciphersuite>(
     sigmas: &[Scalar<C>],
     identifier: Identifier<C>,

--- a/frost-ristretto255/src/keys/repairable.rs
+++ b/frost-ristretto255/src/keys/repairable.rs
@@ -1,4 +1,8 @@
-//! Repairable Threshold Schemes
+//! Repairable Threshold Scheme
+//!
+//! Implements the Repairable Threshold Scheme (RTS) from <https://eprint.iacr.org/2017/1155>.
+//! The RTS is used to help a signer (participant) repair their lost share. This is achieved
+//! using a subset of the other signers know here as `helpers`.
 
 use std::collections::HashMap;
 

--- a/frost-ristretto255/src/keys/repairable.rs
+++ b/frost-ristretto255/src/keys/repairable.rs
@@ -6,7 +6,11 @@
 
 use std::collections::HashMap;
 
-use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, R};
+// This is imported separately to make `gencode` work.
+// (if it were below, the position of the import would vary between ciphersuites
+//  after `cargo fmt`)
+use crate::Ristretto255Sha512;
+use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar};
 
 use super::{SecretShare, VerifiableSecretSharingCommitment};
 
@@ -34,7 +38,7 @@ pub fn repair_share_step_1<C: Ciphersuite, R: RngCore + CryptoRng>(
 ///
 /// Returns a scalar
 pub fn repair_share_step_2(deltas_j: &[Scalar]) -> Scalar {
-    frost::keys::repairable::repair_share_step_2::<R>(deltas_j)
+    frost::keys::repairable::repair_share_step_2::<Ristretto255Sha512>(deltas_j)
 }
 
 /// Step 3 of RTS

--- a/frost-ristretto255/src/keys/repairable.rs
+++ b/frost-ristretto255/src/keys/repairable.rs
@@ -1,11 +1,10 @@
-/// Repairable Threshold Schemes
-#![doc = include_str!("../../repairable.md")]
+//! Repairable Threshold Schemes
 
 use std::collections::HashMap;
 
-use crate::{frost::Identifier, Ciphersuite, CryptoRng, Field, Group, RngCore, Scalar};
+use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, R};
 
-use super::SecretShare;
+use super::{SecretShare, VerifiableSecretSharingCommitment};
 
 /// Step 1 of RTS.
 ///
@@ -14,35 +13,35 @@ use super::SecretShare;
 /// is the share of `helper_i`.
 ///
 /// Returns a HashMap mapping which value should be sent to which participant.
-pub fn repair_share_step_1<R: RngCore + CryptoRng>(
-    helpers: &[Identifier<C>],
-    share_i: &SecretShare<C>,
-    zeta_i: Scalar<C>,
+pub fn repair_share_step_1<C: Ciphersuite, R: RngCore + CryptoRng>(
+    helpers: &[Identifier],
+    share_i: &SecretShare,
     rng: &mut R,
-) -> HashMap<Identifier<C>, Scalar<C>> {
-    frost::keys::repairable::repair_share_step_1(identifier, max_signers, min_signers, &mut rng)
+    participant: Identifier,
+) -> HashMap<Identifier, Scalar> {
+    frost::keys::repairable::repair_share_step_1(helpers, share_i, rng, participant)
 }
 
-/// Step 3 of RTS.
+/// Step 2 of RTS.
 ///
 /// Generates the `sigma` values from all `deltas` received from `helpers`
 /// to help `participant` recover their share.
 /// `sigma` is the sum of all received `delta` and the `delta_i` generated for `helper_i`.
 ///
 /// Returns a scalar
-pub fn repair_share_step_2<C: Ciphersuite>(deltas_j: &[Scalar<C>]) -> Scalar<C> {
-    frost::keys::repairable::repair_share_step_2(deltas_j)
+pub fn repair_share_step_2(deltas_j: &[Scalar]) -> Scalar {
+    frost::keys::repairable::repair_share_step_2::<R>(deltas_j)
 }
 
-/// Step 5 of RTS
+/// Step 3 of RTS
 ///
 /// The `participant` sums all `sigma_j` received to compute the `share`. The `SecretShare`
 /// is made up of the `identifier`and `commitment` of the `participant` as well as the
 /// `value` which is the `SigningShare`.
-pub fn repair_share_step_3<C: Ciphersuite>(
-    sigmas: &[Scalar<C>],
-    identifier: Identifier<C>,
-    commitment: &VerifiableSecretSharingCommitment<C>,
-) -> SecretShare<C> {
-    frost::keys::repairable::repair_share(sigmas, identifier, commitment)
+pub fn repair_share_step_3(
+    sigmas: &[Scalar],
+    identifier: Identifier,
+    commitment: &VerifiableSecretSharingCommitment,
+) -> SecretShare {
+    frost::keys::repairable::repair_share_step_3(sigmas, identifier, commitment)
 }

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -230,6 +230,7 @@ pub mod keys {
     pub type PublicKeyPackage = frost::keys::PublicKeyPackage<R>;
 
     pub mod dkg;
+    pub mod repairable;
 }
 
 /// FROST(ristretto255, SHA-512) Round 1 functionality and types.

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -229,6 +229,20 @@ pub mod keys {
     /// Used for verification purposes before publishing a signature.
     pub type PublicKeyPackage = frost::keys::PublicKeyPackage<R>;
 
+    /// Contains the commitments to the coefficients for our secret polynomial _f_,
+    /// used to generate participants' key shares.
+    ///
+    /// [`VerifiableSecretSharingCommitment`] contains a set of commitments to the coefficients (which
+    /// themselves are scalars) for a secret polynomial f, where f is used to
+    /// generate each ith participant's key share f(i). Participants use this set of
+    /// commitments to perform verifiable secret sharing.
+    ///
+    /// Note that participants MUST be assured that they have the *same*
+    /// [`VerifiableSecretSharingCommitment`], either by performing pairwise comparison, or by using
+    /// some agreed-upon public location for publication, where each participant can
+    /// ensure that they received the correct (and same) value.
+    pub type VerifiableSecretSharingCommitment = frost::keys::VerifiableSecretSharingCommitment<R>;
+
     pub mod dkg;
     pub mod repairable;
 }

--- a/frost-secp256k1/src/keys/repairable.rs
+++ b/frost-secp256k1/src/keys/repairable.rs
@@ -1,15 +1,19 @@
-/// Repairable Threshold Scheme
-
+/// Repairable Threshold Schemes
 #![doc = include_str!("../../repairable.md")]
 
 use std::collections::HashMap;
 
 use crate::{frost::Identifier, Ciphersuite, CryptoRng, Field, Group, RngCore, Scalar};
 
-use super::{SecretShare};
+use super::SecretShare;
 
-/// Generate random values for each helper - 1 for use in computing the value for the final helper
-
+/// Step 1 of RTS.
+///
+/// Generates the "delta" values from `helper_i` to help `participant` recover their share
+/// where `helpers` contains the identifiers of all the helpers (including `helper_i`), and `share_i`
+/// is the share of `helper_i`.
+///
+/// Returns a HashMap mapping which value should be sent to which participant.
 pub fn repair_share_step_1<R: RngCore + CryptoRng>(
     helpers: &[Identifier<C>],
     share_i: &SecretShare<C>,
@@ -19,22 +23,22 @@ pub fn repair_share_step_1<R: RngCore + CryptoRng>(
     frost::keys::repairable::repair_share_step_1(identifier, max_signers, min_signers, &mut rng)
 }
 
-/// # Communication round:
-/// # Helper i sends deltas_i[j] to helper j
-
-/// # deltas_j: values received by j in the communication round
-/// # Output: sigma_j
-
+/// Step 3 of RTS.
+///
+/// Generates the `sigma` values from all `deltas` received from `helpers`
+/// to help `participant` recover their share.
+/// `sigma` is the sum of all received `delta` and the `delta_i` generated for `helper_i`.
+///
+/// Returns a scalar
 pub fn repair_share_step_2<C: Ciphersuite>(deltas_j: &[Scalar<C>]) -> Scalar<C> {
     frost::keys::repairable::repair_share_step_2(deltas_j)
 }
 
-/// # Communication round
-/// # Helper j sends sigma_j to signer r
-
-/// # sigmas: all sigma_j received from each helper j
-/// # Output: share_r: r's secret share
-
+/// Step 5 of RTS
+///
+/// The `participant` sums all `sigma_j` received to compute the `share`. The `SecretShare`
+/// is made up of the `identifier`and `commitment` of the `participant` as well as the
+/// `value` which is the `SigningShare`.
 pub fn repair_share_step_3<C: Ciphersuite>(
     sigmas: &[Scalar<C>],
     identifier: Identifier<C>,

--- a/frost-secp256k1/src/keys/repairable.rs
+++ b/frost-secp256k1/src/keys/repairable.rs
@@ -1,8 +1,12 @@
-//! Repairable Threshold Schemes
+//! Repairable Threshold Scheme
+//!
+//! Implements the Repairable Threshold Scheme (RTS) from <https://eprint.iacr.org/2017/1155>.
+//! The RTS is used to help a signer (participant) repair their lost share. This is achieved
+//! using a subset of the other signers know here as `helpers`.
 
 use std::collections::HashMap;
 
-use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, S};
+use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, R};
 
 use super::{SecretShare, VerifiableSecretSharingCommitment};
 

--- a/frost-secp256k1/src/keys/repairable.rs
+++ b/frost-secp256k1/src/keys/repairable.rs
@@ -6,7 +6,11 @@
 
 use std::collections::HashMap;
 
-use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, R};
+// This is imported separately to make `gencode` work.
+// (if it were below, the position of the import would vary between ciphersuites
+//  after `cargo fmt`)
+use crate::Secp256K1Sha256;
+use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar};
 
 use super::{SecretShare, VerifiableSecretSharingCommitment};
 
@@ -34,7 +38,7 @@ pub fn repair_share_step_1<C: Ciphersuite, R: RngCore + CryptoRng>(
 ///
 /// Returns a scalar
 pub fn repair_share_step_2(deltas_j: &[Scalar]) -> Scalar {
-    frost::keys::repairable::repair_share_step_2::<S>(deltas_j)
+    frost::keys::repairable::repair_share_step_2::<Secp256K1Sha256>(deltas_j)
 }
 
 /// Step 3 of RTS

--- a/frost-secp256k1/src/keys/repairable.rs
+++ b/frost-secp256k1/src/keys/repairable.rs
@@ -1,11 +1,10 @@
-/// Repairable Threshold Schemes
-#![doc = include_str!("../../repairable.md")]
+//! Repairable Threshold Schemes
 
 use std::collections::HashMap;
 
-use crate::{frost::Identifier, Ciphersuite, CryptoRng, Field, Group, RngCore, Scalar};
+use crate::{frost, Ciphersuite, CryptoRng, Identifier, RngCore, Scalar, S};
 
-use super::SecretShare;
+use super::{SecretShare, VerifiableSecretSharingCommitment};
 
 /// Step 1 of RTS.
 ///
@@ -14,35 +13,35 @@ use super::SecretShare;
 /// is the share of `helper_i`.
 ///
 /// Returns a HashMap mapping which value should be sent to which participant.
-pub fn repair_share_step_1<R: RngCore + CryptoRng>(
-    helpers: &[Identifier<C>],
-    share_i: &SecretShare<C>,
-    zeta_i: Scalar<C>,
+pub fn repair_share_step_1<C: Ciphersuite, R: RngCore + CryptoRng>(
+    helpers: &[Identifier],
+    share_i: &SecretShare,
     rng: &mut R,
-) -> HashMap<Identifier<C>, Scalar<C>> {
-    frost::keys::repairable::repair_share_step_1(identifier, max_signers, min_signers, &mut rng)
+    participant: Identifier,
+) -> HashMap<Identifier, Scalar> {
+    frost::keys::repairable::repair_share_step_1(helpers, share_i, rng, participant)
 }
 
-/// Step 3 of RTS.
+/// Step 2 of RTS.
 ///
 /// Generates the `sigma` values from all `deltas` received from `helpers`
 /// to help `participant` recover their share.
 /// `sigma` is the sum of all received `delta` and the `delta_i` generated for `helper_i`.
 ///
 /// Returns a scalar
-pub fn repair_share_step_2<C: Ciphersuite>(deltas_j: &[Scalar<C>]) -> Scalar<C> {
-    frost::keys::repairable::repair_share_step_2(deltas_j)
+pub fn repair_share_step_2(deltas_j: &[Scalar]) -> Scalar {
+    frost::keys::repairable::repair_share_step_2::<S>(deltas_j)
 }
 
-/// Step 5 of RTS
+/// Step 3 of RTS
 ///
 /// The `participant` sums all `sigma_j` received to compute the `share`. The `SecretShare`
 /// is made up of the `identifier`and `commitment` of the `participant` as well as the
 /// `value` which is the `SigningShare`.
-pub fn repair_share_step_3<C: Ciphersuite>(
-    sigmas: &[Scalar<C>],
-    identifier: Identifier<C>,
-    commitment: &VerifiableSecretSharingCommitment<C>,
-) -> SecretShare<C> {
-    frost::keys::repairable::repair_share(sigmas, identifier, commitment)
+pub fn repair_share_step_3(
+    sigmas: &[Scalar],
+    identifier: Identifier,
+    commitment: &VerifiableSecretSharingCommitment,
+) -> SecretShare {
+    frost::keys::repairable::repair_share_step_3(sigmas, identifier, commitment)
 }

--- a/frost-secp256k1/src/lib.rs
+++ b/frost-secp256k1/src/lib.rs
@@ -264,7 +264,22 @@ pub mod keys {
     /// Used for verification purposes before publishing a signature.
     pub type PublicKeyPackage = frost::keys::PublicKeyPackage<S>;
 
+    /// Contains the commitments to the coefficients for our secret polynomial _f_,
+    /// used to generate participants' key shares.
+    ///
+    /// [`VerifiableSecretSharingCommitment`] contains a set of commitments to the coefficients (which
+    /// themselves are scalars) for a secret polynomial f, where f is used to
+    /// generate each ith participant's key share f(i). Participants use this set of
+    /// commitments to perform verifiable secret sharing.
+    ///
+    /// Note that participants MUST be assured that they have the *same*
+    /// [`VerifiableSecretSharingCommitment`], either by performing pairwise comparison, or by using
+    /// some agreed-upon public location for publication, where each participant can
+    /// ensure that they received the correct (and same) value.
+    pub type VerifiableSecretSharingCommitment = frost::keys::VerifiableSecretSharingCommitment<S>;
+
     pub mod dkg;
+    pub mod repairable;
 }
 
 /// FROST(secp256k1, SHA-256) Round 1 functionality and types.

--- a/gencode/src/main.rs
+++ b/gencode/src/main.rs
@@ -215,7 +215,12 @@ fn main() -> ExitCode {
         replaced |= write_docs(&docs, &lib_filename, original_strings, replacement_strings);
 
         // Generate files based on a template with simple search & replace.
-        for filename in ["README.md", "dkg.md", "src/keys/dkg.rs"] {
+        for filename in [
+            "README.md",
+            "dkg.md",
+            "src/keys/dkg.rs",
+            "src/keys/repairable.rs",
+        ] {
             replaced |= copy_and_replace(
                 format!("{original_folder}/{filename}").as_str(),
                 format!("{folder}/{filename}").as_str(),


### PR DESCRIPTION
This changes `gencode` to handle the repairable module: it copies the documentation from `ristretto255` into the other ciphersuite crates.

It's also possible to avoid one other redundancy and copy from `frost-core` into `ristretto255` but that will requires some other tweaks so I'll do that in a separate PR.

I also found some build issues in the ciphersuite-specific repairable modules - we forgot to declare the module so it wasn't being compiled :sweat_smile: 