### PR TITLE
split gencode job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,23 @@ jobs:
           command: fmt
           args: --all -- --check
 
+  gencode:
+    name: Check if automatically generated code is up to date
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3.5.2
+        with:
+          persist-credentials: false
+
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          components: rustfmt
+          override: true
+
+      - uses: Swatinem/rust-cache@v2
+
       - uses: actions-rs/cargo@v1.0.3
         with:
           command: run


### PR DESCRIPTION
When I added the gencode step I was lazy and just added it at the end of the `rustfmt` job, which can be confusing if it fails.

This creates a separate job for it