### PR TITLE
expand list of gencode-generated files

### DIFF
--- a/frost-ed448/src/tests/batch.rs
+++ b/frost-ed448/src/tests/batch.rs
@@ -2,18 +2,14 @@ use rand::thread_rng;
 
 use crate::*;
 
-// TODO: make batching work for larger scalars
-// #[test]
-#[allow(unused)]
+#[test]
 fn check_batch_verify() {
     let rng = thread_rng();
 
     frost_core::tests::batch::batch_verify::<Ed448Shake256, _>(rng);
 }
 
-// TODO: make batching work for larger scalars
-// #[test]
-#[allow(unused)]
+#[test]
 fn check_bad_batch_verify() {
     let rng = thread_rng();
 

--- a/frost-ed448/src/tests/proptests.rs
+++ b/frost-ed448/src/tests/proptests.rs
@@ -1,10 +1,9 @@
+use crate::*;
 use frost_core::tests::proptests::{tweak_strategy, SignatureCase};
 use proptest::prelude::*;
 
 use rand_chacha::ChaChaRng;
 use rand_core::SeedableRng;
-
-use crate::*;
 
 proptest! {
 

--- a/gencode/src/main.rs
+++ b/gencode/src/main.rs
@@ -282,6 +282,10 @@ fn main() -> ExitCode {
             "dkg.md",
             "src/keys/dkg.rs",
             "src/keys/repairable.rs",
+            "src/tests/batch.rs",
+            "src/tests/coefficient_commitment.rs",
+            "src/tests/proptests.rs",
+            "src/tests/vss_commitment.rs",
         ] {
             replaced |= copy_and_replace(
                 format!("{original_folder}/{filename}").as_str(),


### PR DESCRIPTION
Follow-up to #364 

Now that tests have been split we can add the ones that are similar to be generated with `gencode`.

This also ends up restoring the Ed448 batch tests, which are working now.