### PR TITLE
don't import unneeded dependencies when not required

### DIFF
--- a/frost-core/Cargo.toml
+++ b/frost-core/Cargo.toml
@@ -5,7 +5,11 @@ edition = "2021"
 # - Update CHANGELOG.md
 # - Create git tag.
 version = "0.6.0"
-authors = ["Deirdre Connolly <durumcrustulum@gmail.com>", "Chelsea Komlo <me@chelseakomlo.com>", "Conrado Gouvea <conradoplg@gmail.com>"]
+authors = [
+    "Deirdre Connolly <durumcrustulum@gmail.com>",
+    "Chelsea Komlo <me@chelseakomlo.com>",
+    "Conrado Gouvea <conradoplg@gmail.com>",
+]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ZcashFoundation/frost"
@@ -20,7 +24,7 @@ features = ["nightly"]
 byteorder = "1.4"
 debugless-unwrap = "0.0.4"
 derive-getters = "0.3.0"
-hex = { version = "0.4.3", features = ["serde"] }
+hex = "0.4.3"
 rand_core = "0.6"
 serde = { version = "1.0.160", features = ["derive"], optional = true }
 serdect = { version = "0.2.0", optional = true }

--- a/frost-ed25519/Cargo.toml
+++ b/frost-ed25519/Cargo.toml
@@ -22,13 +22,14 @@ description = "A Schnorr signature scheme over Ed25519 that supports FROST."
 features = ["nightly"]
 
 [dependencies]
-curve25519-dalek = { version = "=4.0.0", features = ["serde", "rand_core"] }
-frost-core = { path = "../frost-core", version = "0.6.0", features = ["test-impl"] }
+curve25519-dalek = { version = "=4.0.0", features = ["rand_core"] }
+frost-core = { path = "../frost-core", version = "0.6.0" }
 rand_core = "0.6"
 sha2 = "0.10.2"
 
 [dev-dependencies]
 criterion = "0.5"
+frost-core = { path = "../frost-core", version = "0.6.0", features = ["test-impl"] }
 frost-rerandomized = { path = "../frost-rerandomized", version = "0.6.0", features = ["test-impl"] }
 ed25519-dalek = "2.0.0"
 hex = "0.4.3"

--- a/frost-ed448/Cargo.toml
+++ b/frost-ed448/Cargo.toml
@@ -22,12 +22,13 @@ features = ["nightly"]
 
 [dependencies]
 ed448-goldilocks = { version = "0.9.0" }
-frost-core = { path = "../frost-core", version = "0.6.0", features = ["test-impl"] }
+frost-core = { path = "../frost-core", version = "0.6.0" }
 rand_core = "0.6"
 sha3 = "0.10.6"
 
 [dev-dependencies]
 criterion = "0.5"
+frost-core = { path = "../frost-core", version = "0.6.0", features = ["test-impl"] }
 frost-rerandomized = { path = "../frost-rerandomized", version = "0.6.0", features = ["test-impl"] }
 lazy_static = "1.4"
 hex = "0.4.3"

--- a/frost-p256/Cargo.toml
+++ b/frost-p256/Cargo.toml
@@ -23,12 +23,13 @@ features = ["nightly"]
 
 [dependencies]
 p256 = { version = "0.13.0", features = ["hash2curve"] }
-frost-core = { path = "../frost-core", version = "0.6.0", features = ["test-impl"] }
+frost-core = { path = "../frost-core", version = "0.6.0" }
 rand_core = "0.6"
 sha2 = "0.10.2"
 
 [dev-dependencies]
 criterion = "0.5"
+frost-core = { path = "../frost-core", version = "0.6.0", features = ["test-impl"] }
 frost-rerandomized = { path = "../frost-rerandomized", version = "0.6.0", features = ["test-impl"] }
 hex = "0.4.3"
 lazy_static = "1.4"

--- a/frost-ristretto255/Cargo.toml
+++ b/frost-ristretto255/Cargo.toml
@@ -19,12 +19,13 @@ features = ["nightly"]
 
 [dependencies]
 curve25519-dalek = { version = "=4.0.0", features = ["serde", "rand_core"] }
-frost-core = { path = "../frost-core", version = "0.6.0", features = ["test-impl"] }
+frost-core = { path = "../frost-core", version = "0.6.0" }
 rand_core = "0.6"
 sha2 = "0.10.2"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+frost-core = { path = "../frost-core", version = "0.6.0", features = ["test-impl"] }
 frost-rerandomized = { path = "../frost-rerandomized", version = "0.6.0", features = ["test-impl"] }
 hex = "0.4.3"
 lazy_static = "1.4"

--- a/frost-secp256k1/Cargo.toml
+++ b/frost-secp256k1/Cargo.toml
@@ -21,13 +21,14 @@ description = "A Schnorr signature scheme over the secp256k1 curve that supports
 features = ["nightly"]
 
 [dependencies]
-frost-core = { path = "../frost-core", version = "0.6.0", features = ["test-impl"] }
+frost-core = { path = "../frost-core", version = "0.6.0" }
 k256 = { version = "0.13.0", features = ["arithmetic", "expose-field", "hash2curve"] }
 rand_core = "0.6"
 sha2 = "0.10.2"
 
 [dev-dependencies]
 criterion = "0.5"
+frost-core = { path = "../frost-core", version = "0.6.0", features = ["test-impl"] }
 frost-rerandomized = { path = "../frost-rerandomized", version = "0.6.0", features = ["test-impl"] }
 hex = "0.4.3"
 lazy_static = "1.4"


### PR DESCRIPTION
Closes https://github.com/ZcashFoundation/frost/issues/440

Also solves other issues that I found while fixing that issue:

- criterion was always being imported due to frost-core always being imported with `test-impl` activated

To test this PR you can run e.g. `cargo tree -p frost-core -e normal,build` and check the output for crates that shouldn't be there. Note that you can't omit the crate (`-p frost-core`) because it consolidates all dependencies from all projects, which includes `gencode` (which always uses serde)

