### PR TITLE
improve sign() performance by caching SigningCommitments

### DIFF
--- a/frost-core/src/frost/round2.rs
+++ b/frost-core/src/frost/round2.rs
@@ -11,8 +11,6 @@ use crate::{
 #[cfg(feature = "serde")]
 use crate::ScalarSerialization;
 
-use super::round1::SigningCommitments;
-
 // Used to help encoding a SignatureShare. Since it has a Scalar<C> it can't
 // be directly encoded with serde, so we use this struct to wrap the scalar.
 #[cfg(feature = "serde")]
@@ -195,10 +193,8 @@ pub fn sign<C: Ciphersuite>(
         .get(&key_package.identifier)
         .ok_or(Error::MissingCommitment)?;
 
-    let signing_commitments = SigningCommitments::from(signer_nonces);
-
     // Validate if the signer's commitment exists
-    if &signing_commitments != commitment {
+    if &signer_nonces.commitments != commitment {
         return Err(Error::IncorrectCommitment);
     }
 

--- a/frost-core/src/tests/vectors.rs
+++ b/frost-core/src/tests/vectors.rs
@@ -96,10 +96,10 @@ pub fn parse_test_vectors<C: Ciphersuite>(json_vectors: &Value) -> TestVectors<C
             hex::decode(signer["binding_nonce_randomness"].as_str().unwrap()).unwrap();
         binding_nonces_randomness.insert(identifier, binding_nonce_randomness);
 
-        let signing_nonces = SigningNonces::<C> {
-            hiding: Nonce::<C>::from_hex(signer["hiding_nonce"].as_str().unwrap()).unwrap(),
-            binding: Nonce::<C>::from_hex(signer["binding_nonce"].as_str().unwrap()).unwrap(),
-        };
+        let signing_nonces = SigningNonces::<C>::from_nonces(
+            Nonce::<C>::from_hex(signer["hiding_nonce"].as_str().unwrap()).unwrap(),
+            Nonce::<C>::from_hex(signer["binding_nonce"].as_str().unwrap()).unwrap(),
+        );
 
         signer_nonces.insert(identifier, signing_nonces);
 


### PR DESCRIPTION
Closes https://github.com/ZcashFoundation/frost/issues/454

Benchmark:

```
FROST Signing ristretto255/Round 2/2
                        time:   [97.239 µs 97.456 µs 97.727 µs]
                        change: [-28.248% -28.139% -28.010%] (p = 0.00 < 0.05)
                        Performance has improved.
FROST Signing ristretto255/Round 2/7
                        time:   [180.00 µs 181.16 µs 182.72 µs]
                        change: [-19.124% -18.843% -18.525%] (p = 0.00 < 0.05)
                        Performance has improved.
FROST Signing ristretto255/Round 2/67
                        time:   [1.1946 ms 1.1955 ms 1.1966 ms]
                        change: [-3.4950% -3.2638% -3.0433%] (p = 0.00 < 0.05)
                        Performance has improved.
FROST Signing ristretto255/Round 2/667
                        time:   [11.588 ms 11.607 ms 11.629 ms]
                        change: [-1.4843% -1.2623% -1.0580%] (p = 0.00 < 0.05)
                        Performance has improved.
```