### PR TITLE
return error when creating a zero SigningKey

### DIFF
--- a/frost-core/src/signing_key.rs
+++ b/frost-core/src/signing_key.rs
@@ -30,6 +30,7 @@ where
     ) -> Result<SigningKey<C>, Error<C>> {
         let scalar =
             <<C::Group as Group>::Field as Field>::deserialize(&bytes).map_err(Error::from)?;
+
         if scalar == <<C::Group as Group>::Field as Field>::zero() {
             return Err(Error::MalformedSigningKey);
         }

--- a/frost-core/src/signing_key.rs
+++ b/frost-core/src/signing_key.rs
@@ -34,6 +34,7 @@ where
         if scalar == <<C::Group as Group>::Field as Field>::zero() {
             return Err(Error::MalformedSigningKey);
         }
+
         Ok(Self { scalar })
     }
 

--- a/frost-core/src/signing_key.rs
+++ b/frost-core/src/signing_key.rs
@@ -28,9 +28,12 @@ where
     pub fn deserialize(
         bytes: <<C::Group as Group>::Field as Field>::Serialization,
     ) -> Result<SigningKey<C>, Error<C>> {
-        <<C::Group as Group>::Field as Field>::deserialize(&bytes)
-            .map(|scalar| SigningKey { scalar })
-            .map_err(|e| e.into())
+        let scalar =
+            <<C::Group as Group>::Field as Field>::deserialize(&bytes).map_err(Error::from)?;
+        if scalar == <<C::Group as Group>::Field as Field>::zero() {
+            return Err(Error::MalformedSigningKey);
+        }
+        Ok(Self { scalar })
     }
 
     /// Serialize `SigningKey` to bytes

--- a/frost-core/src/tests/ciphersuite_generic.rs
+++ b/frost-core/src/tests/ciphersuite_generic.rs
@@ -6,11 +6,19 @@ use std::{
 
 use crate::{
     frost::{self, Identifier},
-    Error, Field, Group, Signature, VerifyingKey,
+    Error, Field, Group, Signature, SigningKey, VerifyingKey,
 };
 use rand_core::{CryptoRng, RngCore};
 
 use crate::Ciphersuite;
+
+/// Test if creating a zero SigningKey fails
+pub fn check_zero_key_fails<C: Ciphersuite>() {
+    let zero = <<<C as Ciphersuite>::Group as Group>::Field>::zero();
+    let encoded_zero = <<<C as Ciphersuite>::Group as Group>::Field>::serialize(&zero);
+    let r = SigningKey::<C>::deserialize(encoded_zero);
+    assert_eq!(r, Err(Error::MalformedSigningKey));
+}
 
 /// Test share generation with a Ciphersuite
 pub fn check_share_generation<C: Ciphersuite, R: RngCore + CryptoRng>(mut rng: R) {

--- a/frost-ed25519/tests/integration_tests.rs
+++ b/frost-ed25519/tests/integration_tests.rs
@@ -4,6 +4,11 @@ use rand::thread_rng;
 use serde_json::Value;
 
 #[test]
+fn check_zero_key_fails() {
+    frost_core::tests::ciphersuite_generic::check_zero_key_fails::<Ed25519Sha512>();
+}
+
+#[test]
 fn check_sign_with_dkg() {
     let rng = thread_rng();
 

--- a/frost-ed448/tests/integration_tests.rs
+++ b/frost-ed448/tests/integration_tests.rs
@@ -4,6 +4,11 @@ use rand::thread_rng;
 use serde_json::Value;
 
 #[test]
+fn check_zero_key_fails() {
+    frost_core::tests::ciphersuite_generic::check_zero_key_fails::<Ed448Shake256>();
+}
+
+#[test]
 fn check_sign_with_dkg() {
     let rng = thread_rng();
 

--- a/frost-p256/tests/integration_tests.rs
+++ b/frost-p256/tests/integration_tests.rs
@@ -4,6 +4,11 @@ use rand::thread_rng;
 use serde_json::Value;
 
 #[test]
+fn check_zero_key_fails() {
+    frost_core::tests::ciphersuite_generic::check_zero_key_fails::<P256Sha256>();
+}
+
+#[test]
 fn check_sign_with_dkg() {
     let rng = thread_rng();
 

--- a/frost-ristretto255/tests/integration_tests.rs
+++ b/frost-ristretto255/tests/integration_tests.rs
@@ -4,6 +4,11 @@ use rand::thread_rng;
 use serde_json::Value;
 
 #[test]
+fn check_zero_key_fails() {
+    frost_core::tests::ciphersuite_generic::check_zero_key_fails::<Ristretto255Sha512>();
+}
+
+#[test]
 fn check_sign_with_dkg() {
     let rng = thread_rng();
 

--- a/frost-secp256k1/tests/integration_tests.rs
+++ b/frost-secp256k1/tests/integration_tests.rs
@@ -4,6 +4,11 @@ use rand::thread_rng;
 use serde_json::Value;
 
 #[test]
+fn check_zero_key_fails() {
+    frost_core::tests::ciphersuite_generic::check_zero_key_fails::<Secp256K1Sha256>();
+}
+
+#[test]
 fn check_sign_with_dkg() {
     let rng = thread_rng();
 


### PR DESCRIPTION
Closes https://github.com/ZcashFoundation/frost/issues/465

Since `VerifyingKey::new()` is private, it shouldn't possible to create one from identity, so this addresses the whole issue.