### PR TITLE
Refactor computing the public key package and expose it.

### DIFF
--- a/frost-core/src/frost/keys.rs
+++ b/frost-core/src/frost/keys.rs
@@ -50,7 +50,7 @@ pub(crate) fn compute_verifying_share<C: Ciphersuite>(
     group_commitment: &VerifiableSecretSharingCommitment<C>,
     peer: Identifier<C>,
 ) -> VerifyingShare<C> {
-    VerifyingShare::new(evaluate_vss(group_commitment, peer))
+    VerifyingShare(evaluate_vss(group_commitment, peer))
 }
 
 /// Computes the group public key given the group commitment.
@@ -58,7 +58,9 @@ pub(crate) fn compute_verifying_share<C: Ciphersuite>(
 pub(crate) fn compute_public_key<C: Ciphersuite>(
     group_commitment: &VerifiableSecretSharingCommitment<C>,
 ) -> VerifyingKey<C> {
-    VerifyingKey::new(group_commitment.first().expect("valid commitments").value())
+    VerifyingKey {
+        element: group_commitment.coefficients()[0].value(),
+    }
 }
 
 /// Computes the public key package given a list of commitments.

--- a/frost-core/src/frost/keys.rs
+++ b/frost-core/src/frost/keys.rs
@@ -48,7 +48,7 @@ pub(crate) fn compute_public_key<C: Ciphersuite>(
 ) -> VerifyingKey<C> {
     let mut group_public = <C::Group>::identity();
     for commitment in commitments.values() {
-        group_public = group_public + commitment.first().unwrap().value();
+        group_public = group_public + commitment.first().expect("valid commitments").value();
     }
     VerifyingKey {
         element: group_public,

--- a/frost-core/src/frost/keys.rs
+++ b/frost-core/src/frost/keys.rs
@@ -97,6 +97,12 @@ where
     pub fn serialize(&self) -> <<C::Group as Group>::Field as Field>::Serialization {
         <<C::Group as Group>::Field>::serialize(&self.0)
     }
+
+    /// Computes the signing share from a list of coefficients.
+    #[cfg_attr(feature = "internals", visibility::make(pub))]
+    pub(crate) fn from_coefficients(coefficients: &[Scalar<C>], peer: Identifier<C>) -> Self {
+        Self(evaluate_polynomial(peer, coefficients))
+    }
 }
 
 impl<C> Debug for SigningShare<C>

--- a/frost-core/src/frost/keys.rs
+++ b/frost-core/src/frost/keys.rs
@@ -55,6 +55,7 @@ pub(crate) fn generate_coefficients<C: Ciphersuite, R: RngCore + CryptoRng>(
 }
 
 /// Return a list of default identifiers (1 to max_signers, inclusive).
+#[cfg_attr(feature = "internals", visibility::make(pub))]
 pub(crate) fn default_identifiers<C: Ciphersuite>(max_signers: u16) -> Vec<Identifier<C>> {
     (1..=max_signers)
         .map(|i| Identifier::<C>::try_from(i).expect("nonzero"))

--- a/frost-core/src/frost/keys/dkg.rs
+++ b/frost-core/src/frost/keys/dkg.rs
@@ -449,7 +449,7 @@ pub fn part3<C: Ciphersuite>(
     let signing_share = SigningShare(signing_share);
 
     let commitments = round1_packages
-        .into_iter()
+        .iter()
         .map(|(peer, package)| (*peer, package.commitment.clone()))
         .chain(iter::once((
             round2_secret_package.identifier,
@@ -463,7 +463,7 @@ pub fn part3<C: Ciphersuite>(
         public: *public_key_package
             .signer_pubkeys
             .get(&round2_secret_package.identifier)
-            .unwrap(),
+            .expect("round2_secret_package.commitment is in the hashmap"),
         group_public: public_key_package.group_public,
         ciphersuite: (),
     };

--- a/frost-core/src/frost/keys/dkg.rs
+++ b/frost-core/src/frost/keys/dkg.rs
@@ -40,9 +40,9 @@ use crate::{
 };
 
 use super::{
-    compute_group_commitment, compute_public_key_package, evaluate_polynomial,
-    generate_coefficients, generate_secret_polynomial, validate_num_of_signers, KeyPackage,
-    PublicKeyPackage, SecretShare, SigningShare, VerifiableSecretSharingCommitment,
+    compute_group_commitment, evaluate_polynomial, generate_coefficients,
+    generate_secret_polynomial, validate_num_of_signers, KeyPackage, PublicKeyPackage, SecretShare,
+    SigningShare, VerifiableSecretSharingCommitment,
 };
 
 /// DKG Round 1 structures.
@@ -454,7 +454,7 @@ pub fn part3<C: Ciphersuite>(
         .chain(iter::once(round2_secret_package.commitment.clone()))
         .collect();
     let group_commitment = compute_group_commitment(&commitments);
-    let public_key_package = compute_public_key_package(&members, &group_commitment);
+    let public_key_package = PublicKeyPackage::from_commitment(&members, &group_commitment);
     let key_package = KeyPackage {
         identifier: round2_secret_package.identifier,
         secret_share: signing_share,

--- a/frost-core/src/frost/keys/dkg.rs
+++ b/frost-core/src/frost/keys/dkg.rs
@@ -263,22 +263,8 @@ pub fn part1<C: Ciphersuite, R: RngCore + CryptoRng>(
     let coefficients = generate_coefficients::<C, R>(min_signers as usize - 1, &mut rng);
     let (coefficients, commitment) =
         generate_secret_polynomial(&secret, max_signers, min_signers, coefficients)?;
-
-    // Round 1, Step 2
-    //
-    // > Every P_i computes a proof of knowledge to the corresponding secret
-    // > a_{i0} by calculating σ_i = (R_i, μ_i), such that k ← Z_q, R_i = g^k,
-    // > c_i = H(i, Φ, g^{a_{i0}} , R_i), μ_i = k + a_{i0} · c_i, with Φ being
-    // > a context string to prevent replay attacks.
-
-    let k = <<C::Group as Group>::Field>::random(&mut rng);
-    let R_i = <C::Group>::generator() * k;
-    let c_i =
-        challenge::<C>(identifier, &R_i, &commitment.first()?.0).ok_or(Error::DKGNotSupported)?;
-    let a_i0 = *coefficients
-        .get(0)
-        .expect("coefficients must have at least one element");
-    let mu_i = k + a_i0 * c_i.0;
+    let proof_of_knowledge =
+        construct_proof_of_knowledge(identifier, &coefficients, &commitment, &mut rng)?;
 
     let secret_package = round1::SecretPackage {
         identifier,
@@ -288,7 +274,7 @@ pub fn part1<C: Ciphersuite, R: RngCore + CryptoRng>(
     };
     let package = round1::Package {
         commitment,
-        proof_of_knowledge: Signature { R: R_i, z: mu_i },
+        proof_of_knowledge,
         ciphersuite: (),
     };
 
@@ -311,6 +297,32 @@ where
     preimage.extend_from_slice(<C::Group>::serialize(verifying_key).as_ref());
 
     Some(Challenge(C::HDKG(&preimage[..])?))
+}
+
+/// Constructs the proof of knowledge of the secret coefficients used to generate
+/// the public secret sharing commitment.
+#[cfg_attr(feature = "internals", visibility::make(pub))]
+pub(crate) fn construct_proof_of_knowledge<C: Ciphersuite, R: RngCore + CryptoRng>(
+    identifier: Identifier<C>,
+    coefficients: &[Scalar<C>],
+    commitment: &VerifiableSecretSharingCommitment<C>,
+    mut rng: R,
+) -> Result<Signature<C>, Error<C>> {
+    // Round 1, Step 2
+    //
+    // > Every P_i computes a proof of knowledge to the corresponding secret
+    // > a_{i0} by calculating σ_i = (R_i, μ_i), such that k ← Z_q, R_i = g^k,
+    // > c_i = H(i, Φ, g^{a_{i0}} , R_i), μ_i = k + a_{i0} · c_i, with Φ being
+    // > a context string to prevent replay attacks.
+    let k = <<C::Group as Group>::Field>::random(&mut rng);
+    let R_i = <C::Group>::generator() * k;
+    let c_i =
+        challenge::<C>(identifier, &R_i, &commitment.first()?.0).ok_or(Error::DKGNotSupported)?;
+    let a_i0 = *coefficients
+        .get(0)
+        .expect("coefficients must have at least one element");
+    let mu_i = k + a_i0 * c_i.0;
+    Ok(Signature { R: R_i, z: mu_i })
 }
 
 /// Verifies the proof of knowledge of the secret coefficients used to generate the

--- a/frost-core/src/frost/keys/dkg.rs
+++ b/frost-core/src/frost/keys/dkg.rs
@@ -111,6 +111,17 @@ pub mod round1 {
         pub(crate) max_signers: u16,
     }
 
+    impl<C> SecretPackage<C>
+    where
+        C: Ciphersuite,
+    {
+        #[cfg(feature = "internals")]
+        /// Returns the secret coefficients.
+        pub fn coefficients(&self) -> &[Scalar<C>] {
+            &self.coefficients
+        }
+    }
+
     impl<C> std::fmt::Debug for SecretPackage<C>
     where
         C: Ciphersuite,

--- a/frost-core/src/tests/repairable.rs
+++ b/frost-core/src/tests/repairable.rs
@@ -11,7 +11,7 @@ use crate::{
         self, compute_lagrange_coefficient,
         keys::{
             repairable::{repair_share_step_1, repair_share_step_2, repair_share_step_3},
-            PublicKeyPackage, SecretShare, SigningShare,
+            KeyPackage, PublicKeyPackage, SecretShare, SigningShare,
         },
         Identifier,
     },

--- a/frost-core/src/tests/vss_commitment.rs
+++ b/frost-core/src/tests/vss_commitment.rs
@@ -13,8 +13,8 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 use crate::frost::keys::{
-    compute_group_commitment, compute_public_key_package, generate_with_dealer, reconstruct,
-    IdentifierList, KeyPackage, PublicKeyPackage, SecretShare, SigningShare, VerifyingShare,
+    compute_group_commitment, generate_with_dealer, reconstruct, IdentifierList, KeyPackage,
+    PublicKeyPackage, SecretShare, SigningShare, VerifyingShare,
 };
 use crate::{Ciphersuite, Field, VerifyingKey};
 
@@ -155,7 +155,7 @@ pub fn check_compute_public_key_package<C: Ciphersuite, R: RngCore + CryptoRng>(
     let public_key_package = PublicKeyPackage::new(verifying_shares, group_public);
     assert_eq!(
         public_key_package,
-        compute_public_key_package(&members, &group_commitment)
+        PublicKeyPackage::from_commitment(&members, &group_commitment)
     );
     let signing_key = reconstruct(&secret_shares[..min_signers as usize]).unwrap();
     assert_eq!(

--- a/frost-core/src/verifying_key.rs
+++ b/frost-core/src/verifying_key.rs
@@ -76,6 +76,16 @@ where
     pub fn verify(&self, msg: &[u8], signature: &Signature<C>) -> Result<(), Error<C>> {
         C::verify_signature(msg, signature, self)
     }
+
+    /// Computes the group public key given the group commitment.
+    #[cfg_attr(feature = "internals", visibility::make(pub))]
+    pub(crate) fn from_commitment(
+        commitment: &crate::frost::keys::VerifiableSecretSharingCommitment<C>,
+    ) -> VerifyingKey<C> {
+        VerifyingKey {
+            element: commitment.coefficients()[0].value(),
+        }
+    }
 }
 
 impl<C> Debug for VerifyingKey<C>

--- a/frost-secp256k1/src/tests/vss_commitment.rs
+++ b/frost-secp256k1/src/tests/vss_commitment.rs
@@ -30,3 +30,9 @@ fn check_deserialize_vss_commitment_error() {
         rng, &ELEMENTS,
     );
 }
+
+#[test]
+fn check_compute_public_key_package() {
+    let rng = thread_rng();
+    frost_core::tests::vss_commitment::check_compute_public_key_package::<Secp256K1Sha256, _>(rng);
+}


### PR DESCRIPTION
These are useful for other crates. Our particular use case is integrating frost with substrate. So we store the verifiable secret sharing commitments on chain. If a node crashes it can recover and recompute the public key package from the on chain commitments.