### PR TITLE
ci: run tests with --release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: --all-features
+          args: --release --all-features
 
   clippy:
     name: Clippy


### PR DESCRIPTION
Tests are much faster with `--release` so this adds the flag in CI