### PR TITLE
change reconstruct() to take KeyPackages; validate size 

### DIFF
--- a/frost-core/CHANGELOG.md
+++ b/frost-core/CHANGELOG.md
@@ -11,6 +11,8 @@ Entries are listed in reverse chronological order.
   running previous versions.
 * A new `min_signers` field was added to `KeyPackage`, which changes its
   `new()` method and its serde serialization.
+* `reconstruct()` was changed to take a slice of `KeyPackage`s instead of
+  `SecretShare`s since users are expect to store the former and not the latter.
 
 ## Released
 

--- a/frost-ed25519/src/lib.rs
+++ b/frost-ed25519/src/lib.rs
@@ -266,7 +266,7 @@ pub mod keys {
     ///
     /// The caller is responsible for providing at least `min_signers` shares;
     /// if less than that is provided, a different key will be returned.
-    pub fn reconstruct(secret_shares: &[SecretShare]) -> Result<SigningKey, Error> {
+    pub fn reconstruct(secret_shares: &[KeyPackage]) -> Result<SigningKey, Error> {
         frost::keys::reconstruct(secret_shares)
     }
 

--- a/frost-ed448/src/lib.rs
+++ b/frost-ed448/src/lib.rs
@@ -260,7 +260,7 @@ pub mod keys {
     ///
     /// The caller is responsible for providing at least `min_signers` shares;
     /// if less than that is provided, a different key will be returned.
-    pub fn reconstruct(secret_shares: &[SecretShare]) -> Result<SigningKey, Error> {
+    pub fn reconstruct(secret_shares: &[KeyPackage]) -> Result<SigningKey, Error> {
         frost::keys::reconstruct(secret_shares)
     }
 

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -292,7 +292,7 @@ pub mod keys {
     ///
     /// The caller is responsible for providing at least `min_signers` shares;
     /// if less than that is provided, a different key will be returned.
-    pub fn reconstruct(secret_shares: &[SecretShare]) -> Result<SigningKey, Error> {
+    pub fn reconstruct(secret_shares: &[KeyPackage]) -> Result<SigningKey, Error> {
         frost::keys::reconstruct(secret_shares)
     }
 

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -251,7 +251,7 @@ pub mod keys {
     ///
     /// The caller is responsible for providing at least `min_signers` shares;
     /// if less than that is provided, a different key will be returned.
-    pub fn reconstruct(secret_shares: &[SecretShare]) -> Result<SigningKey, Error> {
+    pub fn reconstruct(secret_shares: &[KeyPackage]) -> Result<SigningKey, Error> {
         frost::keys::reconstruct(secret_shares)
     }
 

--- a/frost-secp256k1/src/lib.rs
+++ b/frost-secp256k1/src/lib.rs
@@ -291,7 +291,7 @@ pub mod keys {
     ///
     /// The caller is responsible for providing at least `min_signers` shares;
     /// if less than that is provided, a different key will be returned.
-    pub fn reconstruct(secret_shares: &[SecretShare]) -> Result<SigningKey, Error> {
+    pub fn reconstruct(secret_shares: &[KeyPackage]) -> Result<SigningKey, Error> {
         frost::keys::reconstruct(secret_shares)
     }
 


### PR DESCRIPTION
Depends on https://github.com/ZcashFoundation/frost/pull/480

Closes https://github.com/ZcashFoundation/frost/issues/458

This also changes `reconstruct()` to take `KeyPackages`s instead of `SecretShare`s which made no sense - users are expect to convert `SecretShare`s into `KeyPackage`s and store that.