### PR TITLE
ci: remove protoc install

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,13 +40,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install last version of Protoc
-        uses: arduino/setup-protoc@v1.2.0
-        with:
-          # TODO: increase to latest version after https://github.com/arduino/setup-protoc/issues/33 is fixed
-          version: '3.20.1'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install latest beta
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
I think this was a leftover from the zebra CI and is not needed. 