### PR TITLE
remove serde bounds from Ciphersuites

### DIFF
--- a/frost-core/src/frost.rs
+++ b/frost-core/src/frost.rs
@@ -212,6 +212,7 @@ fn derive_interpolating_value<C: Ciphersuite>(
 /// each signing party
 #[derive(Clone, Debug, PartialEq, Eq, Getters)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct SigningPackage<C: Ciphersuite> {
     /// The set of commitments participants published in the first round of the
@@ -309,7 +310,7 @@ where
 #[cfg(feature = "serialization")]
 impl<C> SigningPackage<C>
 where
-    C: Ciphersuite + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    C: Ciphersuite,
 {
     /// Serialize the struct into a Vec.
     pub fn serialize(&self) -> Result<Vec<u8>, Error<C>> {

--- a/frost-core/src/frost/identifier.rs
+++ b/frost-core/src/frost/identifier.rs
@@ -17,6 +17,7 @@ use crate::ScalarSerialization;
 /// field, as f(0) = the shared secret.
 #[derive(Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 #[cfg_attr(feature = "serde", serde(try_from = "ScalarSerialization<C>"))]
 #[cfg_attr(feature = "serde", serde(into = "ScalarSerialization<C>"))]
 pub struct Identifier<C: Ciphersuite>(Scalar<C>);

--- a/frost-core/src/frost/keys.rs
+++ b/frost-core/src/frost/keys.rs
@@ -49,6 +49,7 @@ pub(crate) fn default_identifiers<C: Ciphersuite>(max_signers: u16) -> Vec<Ident
 /// A secret scalar value representing a signer's share of the group secret.
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 #[cfg_attr(feature = "serde", serde(try_from = "ScalarSerialization<C>"))]
 #[cfg_attr(feature = "serde", serde(into = "ScalarSerialization<C>"))]
 pub struct SigningShare<C: Ciphersuite>(pub(crate) Scalar<C>);
@@ -146,6 +147,7 @@ where
 /// A public group element that represents a single signer's public verification share.
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 #[cfg_attr(feature = "serde", serde(try_from = "ElementSerialization<C>"))]
 #[cfg_attr(feature = "serde", serde(into = "ElementSerialization<C>"))]
 pub struct VerifyingShare<C>(pub(super) Element<C>)
@@ -229,6 +231,7 @@ where
 /// verifiable secret sharing for a Shamir secret share.
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 #[cfg_attr(feature = "serde", serde(try_from = "ElementSerialization<C>"))]
 #[cfg_attr(feature = "serde", serde(into = "ElementSerialization<C>"))]
 pub struct CoefficientCommitment<C: Ciphersuite>(pub(crate) Element<C>);
@@ -302,6 +305,7 @@ where
 /// ensure that they received the correct (and same) value.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 pub struct VerifiableSecretSharingCommitment<C: Ciphersuite>(
     pub(crate) Vec<CoefficientCommitment<C>>,
 );
@@ -350,6 +354,7 @@ where
 /// .into(), which under the hood also performs validation.
 #[derive(Clone, Debug, Zeroize, PartialEq, Eq, Getters)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct SecretShare<C: Ciphersuite> {
     /// The participant identifier of this [`SecretShare`].
@@ -424,7 +429,7 @@ where
 #[cfg(feature = "serialization")]
 impl<C> SecretShare<C>
 where
-    C: Ciphersuite + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    C: Ciphersuite,
 {
     /// Serialize the struct into a Vec.
     pub fn serialize(&self) -> Result<Vec<u8>, Error<C>> {
@@ -575,6 +580,7 @@ fn evaluate_vss<C: Ciphersuite>(
 /// [`KeyPackage`]s, which they store to later use during signing.
 #[derive(Clone, Debug, PartialEq, Eq, Getters, Zeroize)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct KeyPackage<C: Ciphersuite> {
     /// Denotes the participant identifier each secret share key package is owned by.
@@ -628,7 +634,7 @@ where
 #[cfg(feature = "serialization")]
 impl<C> KeyPackage<C>
 where
-    C: Ciphersuite + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    C: Ciphersuite,
 {
     /// Serialize the struct into a Vec.
     pub fn serialize(&self) -> Result<Vec<u8>, Error<C>> {
@@ -675,6 +681,7 @@ where
 /// Used for verification purposes before publishing a signature.
 #[derive(Clone, Debug, PartialEq, Eq, Getters)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct PublicKeyPackage<C: Ciphersuite> {
     /// The verifying shares for all participants. Used to validate signature
@@ -715,7 +722,7 @@ where
 #[cfg(feature = "serialization")]
 impl<C> PublicKeyPackage<C>
 where
-    C: Ciphersuite + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    C: Ciphersuite,
 {
     /// Serialize the struct into a Vec.
     pub fn serialize(&self) -> Result<Vec<u8>, Error<C>> {

--- a/frost-core/src/frost/keys/dkg.rs
+++ b/frost-core/src/frost/keys/dkg.rs
@@ -58,6 +58,7 @@ pub mod round1 {
     /// between the first and second parts of the DKG protocol (round 1).
     #[derive(Clone, Debug, PartialEq, Eq, Getters)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
     #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
     pub struct Package<C: Ciphersuite> {
         /// The public commitment from the participant (C_i)
@@ -97,7 +98,7 @@ pub mod round1 {
     #[cfg(feature = "serialization")]
     impl<C> Package<C>
     where
-        C: Ciphersuite + serde::Serialize + for<'de> serde::Deserialize<'de>,
+        C: Ciphersuite,
     {
         /// Serialize the struct into a Vec.
         pub fn serialize(&self) -> Result<Vec<u8>, Error<C>> {
@@ -176,6 +177,7 @@ pub mod round2 {
     /// The package must be sent on an *confidential* and *authenticated* channel.
     #[derive(Clone, Debug, PartialEq, Eq, Getters)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+    #[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
     #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
     pub struct Package<C: Ciphersuite> {
         /// The secret share being sent.
@@ -209,7 +211,7 @@ pub mod round2 {
     #[cfg(feature = "serialization")]
     impl<C> Package<C>
     where
-        C: Ciphersuite + serde::Serialize + for<'de> serde::Deserialize<'de>,
+        C: Ciphersuite,
     {
         /// Serialize the struct into a Vec.
         pub fn serialize(&self) -> Result<Vec<u8>, Error<C>> {

--- a/frost-core/src/frost/round1.rs
+++ b/frost-core/src/frost/round1.rs
@@ -106,6 +106,7 @@ where
 /// A group element that is a commitment to a signing nonce share.
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 #[cfg_attr(feature = "serde", serde(try_from = "ElementSerialization<C>"))]
 #[cfg_attr(feature = "serde", serde(into = "ElementSerialization<C>"))]
 pub struct NonceCommitment<C: Ciphersuite>(pub(super) Element<C>);
@@ -266,6 +267,7 @@ where
 /// SigningCommitment can be used for exactly *one* signature.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Getters)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 pub struct SigningCommitments<C: Ciphersuite> {
     /// Commitment to the hiding [`Nonce`].
@@ -314,7 +316,7 @@ where
 #[cfg(feature = "serialization")]
 impl<C> SigningCommitments<C>
 where
-    C: Ciphersuite + serde::Serialize + for<'de> serde::Deserialize<'de>,
+    C: Ciphersuite,
 {
     /// Serialize the struct into a Vec.
     pub fn serialize(&self) -> Result<Vec<u8>, Error<C>> {

--- a/frost-core/src/frost/round2.rs
+++ b/frost-core/src/frost/round2.rs
@@ -16,6 +16,7 @@ use crate::ScalarSerialization;
 #[cfg(feature = "serde")]
 #[derive(Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 #[cfg_attr(feature = "serde", serde(try_from = "ScalarSerialization<C>"))]
 #[cfg_attr(feature = "serde", serde(into = "ScalarSerialization<C>"))]
 struct SignatureShareHelper<C: Ciphersuite>(Scalar<C>);
@@ -48,6 +49,7 @@ where
 /// shares into the joint signature.
 #[derive(Clone, Copy, Eq, PartialEq, Getters)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 #[cfg_attr(feature = "serde", serde(try_from = "SignatureShareSerialization<C>"))]
 #[cfg_attr(feature = "serde", serde(into = "SignatureShareSerialization<C>"))]
@@ -104,6 +106,7 @@ where
 
 #[cfg(feature = "serde")]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
 struct SignatureShareSerialization<C: Ciphersuite> {
     share: SignatureShareHelper<C>,

--- a/frost-core/src/verifying_key.rs
+++ b/frost-core/src/verifying_key.rs
@@ -11,6 +11,7 @@ use crate::ElementSerialization;
 /// A valid verifying key for Schnorr signatures over a FROST [`Ciphersuite::Group`].
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 #[cfg_attr(feature = "serde", serde(try_from = "ElementSerialization<C>"))]
 #[cfg_attr(feature = "serde", serde(into = "ElementSerialization<C>"))]
 pub struct VerifyingKey<C>

--- a/frost-ed25519/src/lib.rs
+++ b/frost-ed25519/src/lib.rs
@@ -18,9 +18,6 @@ use sha2::{Digest, Sha512};
 
 use frost_core::frost;
 
-#[cfg(feature = "serde")]
-use frost_core::serde;
-
 #[cfg(test)]
 mod tests;
 
@@ -155,8 +152,6 @@ const CONTEXT_STRING: &str = "FROST-ED25519-SHA512-v1";
 
 /// An implementation of the FROST(Ed25519, SHA-512) ciphersuite.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(crate = "self::serde"))]
 pub struct Ed25519Sha512;
 
 impl Ciphersuite for Ed25519Sha512 {

--- a/frost-ed448/src/lib.rs
+++ b/frost-ed448/src/lib.rs
@@ -19,9 +19,6 @@ use sha3::{
 
 use frost_core::frost;
 
-#[cfg(feature = "serde")]
-use frost_core::serde;
-
 #[cfg(test)]
 mod tests;
 
@@ -150,8 +147,6 @@ const CONTEXT_STRING: &str = "FROST-ED448-SHAKE256-v1";
 
 /// An implementation of the FROST(Ed448, SHAKE256) ciphersuite.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(crate = "self::serde"))]
 pub struct Ed448Shake256;
 
 impl Ciphersuite for Ed448Shake256 {

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -20,9 +20,6 @@ use sha2::{Digest, Sha256};
 
 use frost_core::frost;
 
-#[cfg(feature = "serde")]
-use frost_core::serde;
-
 #[cfg(test)]
 mod tests;
 
@@ -175,8 +172,6 @@ const CONTEXT_STRING: &str = "FROST-P256-SHA256-v1";
 
 /// An implementation of the FROST(P-256, SHA-256) ciphersuite.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(crate = "self::serde"))]
 pub struct P256Sha256;
 
 impl Ciphersuite for P256Sha256 {

--- a/frost-rerandomized/src/lib.rs
+++ b/frost-rerandomized/src/lib.rs
@@ -150,6 +150,7 @@ where
 /// A randomizer. A random scalar which is used to randomize the key.
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
 #[cfg_attr(feature = "serde", serde(try_from = "ScalarSerialization<C>"))]
 #[cfg_attr(feature = "serde", serde(into = "ScalarSerialization<C>"))]
 #[cfg_attr(feature = "serde", serde(crate = "self::serde"))]

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -15,9 +15,6 @@ use sha2::{Digest, Sha512};
 
 use frost_core::frost;
 
-#[cfg(feature = "serde")]
-use frost_core::serde;
-
 #[cfg(test)]
 mod tests;
 
@@ -141,8 +138,6 @@ const CONTEXT_STRING: &str = "FROST-RISTRETTO255-SHA512-v1";
 
 /// An implementation of the FROST(ristretto255, SHA-512) ciphersuite.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(crate = "self::serde"))]
 pub struct Ristretto255Sha512;
 
 impl Ciphersuite for Ristretto255Sha512 {

--- a/frost-secp256k1/src/lib.rs
+++ b/frost-secp256k1/src/lib.rs
@@ -21,9 +21,6 @@ use sha2::{Digest, Sha256};
 
 use frost_core::frost;
 
-#[cfg(feature = "serde")]
-use frost_core::serde;
-
 #[cfg(test)]
 mod tests;
 
@@ -175,8 +172,6 @@ const CONTEXT_STRING: &str = "FROST-secp256k1-SHA256-v1";
 
 /// An implementation of the FROST(secp256k1, SHA-256) ciphersuite.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(crate = "self::serde"))]
 pub struct Secp256K1Sha256;
 
 impl Ciphersuite for Secp256K1Sha256 {


### PR DESCRIPTION
When using `derive`, serde adds bounds to (De)Serialize even to the Ciphersuite itself, even though that's not required. That is annoying because it requires us to add the bounds to all ciphersuite structs, but more importantly, is making things much harder in #525 since it needs to use the new default serialization methods which require serde.

This uses `serde(bound = "C: Ciphersuite")` to remove those bounds. See https://stackoverflow.com/questions/76107066/how-to-help-deserializer-understand-that-generics-dont-need-deserialize-bound.

Part of #525 but does not close it.