### PR TITLE
dependabot: remove hardcoded reviewer and assignee

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,17 +6,9 @@ updates:
     interval: daily
     timezone: America/New_York
   open-pull-requests-limit: 10
-  reviewers:
-  - dconnolly
-  assignees:
-  - dconnolly
 - package-ecosystem: cargo
   directory: "/"
   schedule:
     interval: daily
     timezone: America/New_York
   open-pull-requests-limit: 10
-  reviewers:
-  - dconnolly
-  assignees:
-  - dconnolly


### PR DESCRIPTION
I figured we can just omit it and assign it ourselves per availability