### PR TITLE
add verifiable key resharing module

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -9,7 +9,7 @@ title = "The ZF FROST Book"
 
 [preprocessor.admonish]
 command = "mdbook-admonish"
-assets_version = "2.0.1" # do not edit: managed by `mdbook-admonish install`
+assets_version = "3.0.0" # do not edit: managed by `mdbook-admonish install`
 
 [output]
 

--- a/book/mdbook-admonish.css
+++ b/book/mdbook-admonish.css
@@ -1,31 +1,18 @@
 @charset "UTF-8";
 :root {
-  --md-admonition-icon--note:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M20.71 7.04c.39-.39.39-1.04 0-1.41l-2.34-2.34c-.37-.39-1.02-.39-1.41 0l-1.84 1.83 3.75 3.75M3 17.25V21h3.75L17.81 9.93l-3.75-3.75L3 17.25z'/></svg>");
-  --md-admonition-icon--abstract:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M17 9H7V7h10m0 6H7v-2h10m-3 6H7v-2h7M12 3a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1m7 0h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2z'/></svg>");
-  --md-admonition-icon--info:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 9h-2V7h2m0 10h-2v-6h2m-1-9A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z'/></svg>");
-  --md-admonition-icon--tip:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M17.66 11.2c-.23-.3-.51-.56-.77-.82-.67-.6-1.43-1.03-2.07-1.66C13.33 7.26 13 4.85 13.95 3c-.95.23-1.78.75-2.49 1.32-2.59 2.08-3.61 5.75-2.39 8.9.04.1.08.2.08.33 0 .22-.15.42-.35.5-.23.1-.47.04-.66-.12a.58.58 0 0 1-.14-.17c-1.13-1.43-1.31-3.48-.55-5.12C5.78 10 4.87 12.3 5 14.47c.06.5.12 1 .29 1.5.14.6.41 1.2.71 1.73 1.08 1.73 2.95 2.97 4.96 3.22 2.14.27 4.43-.12 6.07-1.6 1.83-1.66 2.47-4.32 1.53-6.6l-.13-.26c-.21-.46-.77-1.26-.77-1.26m-3.16 6.3c-.28.24-.74.5-1.1.6-1.12.4-2.24-.16-2.9-.82 1.19-.28 1.9-1.16 2.11-2.05.17-.8-.15-1.46-.28-2.23-.12-.74-.1-1.37.17-2.06.19.38.39.76.63 1.06.77 1 1.98 1.44 2.24 2.8.04.14.06.28.06.43.03.82-.33 1.72-.93 2.27z'/></svg>");
-  --md-admonition-icon--success:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='m9 20.42-6.21-6.21 2.83-2.83L9 14.77l9.88-9.89 2.83 2.83L9 20.42z'/></svg>");
-  --md-admonition-icon--question:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='m15.07 11.25-.9.92C13.45 12.89 13 13.5 13 15h-2v-.5c0-1.11.45-2.11 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41a2 2 0 0 0-2-2 2 2 0 0 0-2 2H8a4 4 0 0 1 4-4 4 4 0 0 1 4 4 3.2 3.2 0 0 1-.93 2.25M13 19h-2v-2h2M12 2A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10c0-5.53-4.5-10-10-10z'/></svg>");
-  --md-admonition-icon--warning:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 14h-2V9h2m0 9h-2v-2h2M1 21h22L12 2 1 21z'/></svg>");
-  --md-admonition-icon--failure:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M20 6.91 17.09 4 12 9.09 6.91 4 4 6.91 9.09 12 4 17.09 6.91 20 12 14.91 17.09 20 20 17.09 14.91 12 20 6.91z'/></svg>");
-  --md-admonition-icon--danger:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M11 15H6l7-14v8h5l-7 14v-8z'/></svg>");
-  --md-admonition-icon--bug:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 12h-4v-2h4m0 6h-4v-2h4m6-6h-2.81a5.985 5.985 0 0 0-1.82-1.96L17 4.41 15.59 3l-2.17 2.17a6.002 6.002 0 0 0-2.83 0L8.41 3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05.33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21 5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8z'/></svg>");
-  --md-admonition-icon--example:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M7 13v-2h14v2H7m0 6v-2h14v2H7M7 7V5h14v2H7M3 8V5H2V4h2v4H3m-1 9v-1h3v4H2v-1h2v-.5H3v-1h1V17H2m2.25-7a.75.75 0 0 1 .75.75c0 .2-.08.39-.21.52L3.12 13H5v1H2v-.92L4 11H2v-1h2.25z'/></svg>");
-  --md-admonition-icon--quote:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 17h3l2-4V7h-6v6h3M6 17h3l2-4V7H5v6h3l-2 4z'/></svg>");
-  --md-details-icon:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M8.59 16.58 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42Z'/></svg>");
+  --md-admonition-icon--admonish-note: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M20.71 7.04c.39-.39.39-1.04 0-1.41l-2.34-2.34c-.37-.39-1.02-.39-1.41 0l-1.84 1.83 3.75 3.75M3 17.25V21h3.75L17.81 9.93l-3.75-3.75L3 17.25z'/></svg>");
+  --md-admonition-icon--admonish-abstract: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M17 9H7V7h10m0 6H7v-2h10m-3 6H7v-2h7M12 3a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1m7 0h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2z'/></svg>");
+  --md-admonition-icon--admonish-info: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 9h-2V7h2m0 10h-2v-6h2m-1-9A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z'/></svg>");
+  --md-admonition-icon--admonish-tip: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M17.66 11.2c-.23-.3-.51-.56-.77-.82-.67-.6-1.43-1.03-2.07-1.66C13.33 7.26 13 4.85 13.95 3c-.95.23-1.78.75-2.49 1.32-2.59 2.08-3.61 5.75-2.39 8.9.04.1.08.2.08.33 0 .22-.15.42-.35.5-.23.1-.47.04-.66-.12a.58.58 0 0 1-.14-.17c-1.13-1.43-1.31-3.48-.55-5.12C5.78 10 4.87 12.3 5 14.47c.06.5.12 1 .29 1.5.14.6.41 1.2.71 1.73 1.08 1.73 2.95 2.97 4.96 3.22 2.14.27 4.43-.12 6.07-1.6 1.83-1.66 2.47-4.32 1.53-6.6l-.13-.26c-.21-.46-.77-1.26-.77-1.26m-3.16 6.3c-.28.24-.74.5-1.1.6-1.12.4-2.24-.16-2.9-.82 1.19-.28 1.9-1.16 2.11-2.05.17-.8-.15-1.46-.28-2.23-.12-.74-.1-1.37.17-2.06.19.38.39.76.63 1.06.77 1 1.98 1.44 2.24 2.8.04.14.06.28.06.43.03.82-.33 1.72-.93 2.27z'/></svg>");
+  --md-admonition-icon--admonish-success: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='m9 20.42-6.21-6.21 2.83-2.83L9 14.77l9.88-9.89 2.83 2.83L9 20.42z'/></svg>");
+  --md-admonition-icon--admonish-question: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='m15.07 11.25-.9.92C13.45 12.89 13 13.5 13 15h-2v-.5c0-1.11.45-2.11 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41a2 2 0 0 0-2-2 2 2 0 0 0-2 2H8a4 4 0 0 1 4-4 4 4 0 0 1 4 4 3.2 3.2 0 0 1-.93 2.25M13 19h-2v-2h2M12 2A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10c0-5.53-4.5-10-10-10z'/></svg>");
+  --md-admonition-icon--admonish-warning: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 14h-2V9h2m0 9h-2v-2h2M1 21h22L12 2 1 21z'/></svg>");
+  --md-admonition-icon--admonish-failure: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M20 6.91 17.09 4 12 9.09 6.91 4 4 6.91 9.09 12 4 17.09 6.91 20 12 14.91 17.09 20 20 17.09 14.91 12 20 6.91z'/></svg>");
+  --md-admonition-icon--admonish-danger: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M11 15H6l7-14v8h5l-7 14v-8z'/></svg>");
+  --md-admonition-icon--admonish-bug: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 12h-4v-2h4m0 6h-4v-2h4m6-6h-2.81a5.985 5.985 0 0 0-1.82-1.96L17 4.41 15.59 3l-2.17 2.17a6.002 6.002 0 0 0-2.83 0L8.41 3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05.33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21 5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8z'/></svg>");
+  --md-admonition-icon--admonish-example: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M7 13v-2h14v2H7m0 6v-2h14v2H7M7 7V5h14v2H7M3 8V5H2V4h2v4H3m-1 9v-1h3v4H2v-1h2v-.5H3v-1h1V17H2m2.25-7a.75.75 0 0 1 .75.75c0 .2-.08.39-.21.52L3.12 13H5v1H2v-.92L4 11H2v-1h2.25z'/></svg>");
+  --md-admonition-icon--admonish-quote: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 17h3l2-4V7h-6v6h3M6 17h3l2-4V7H5v6h3l-2 4z'/></svg>");
+  --md-details-icon: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M8.59 16.58 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42Z'/></svg>");
 }
 
 :is(.admonition) {
@@ -75,7 +62,7 @@ a.admonition-anchor-link::before {
   content: "§";
 }
 
-:is(.admonition-title, summary) {
+:is(.admonition-title, summary.admonition-title) {
   position: relative;
   min-height: 4rem;
   margin-block: 0;
@@ -86,13 +73,13 @@ a.admonition-anchor-link::before {
   background-color: rgba(68, 138, 255, 0.1);
   display: flex;
 }
-:is(.admonition-title, summary) p {
+:is(.admonition-title, summary.admonition-title) p {
   margin: 0;
 }
-html :is(.admonition-title, summary):last-child {
+html :is(.admonition-title, summary.admonition-title):last-child {
   margin-bottom: 0;
 }
-:is(.admonition-title, summary)::before {
+:is(.admonition-title, summary.admonition-title)::before {
   position: absolute;
   top: 0.625em;
   inset-inline-start: 1.6rem;
@@ -107,7 +94,7 @@ html :is(.admonition-title, summary):last-child {
   -webkit-mask-size: contain;
   content: "";
 }
-:is(.admonition-title, summary):hover a.admonition-anchor-link {
+:is(.admonition-title, summary.admonition-title):hover a.admonition-anchor-link {
   display: initial;
 }
 
@@ -132,204 +119,204 @@ details[open].admonition > summary.admonition-title::after {
   transform: rotate(90deg);
 }
 
-:is(.admonition):is(.note) {
+:is(.admonition):is(.admonish-note) {
   border-color: #448aff;
 }
 
-:is(.note) > :is(.admonition-title, summary) {
+:is(.admonish-note) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(68, 138, 255, 0.1);
 }
-:is(.note) > :is(.admonition-title, summary)::before {
+:is(.admonish-note) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #448aff;
-  mask-image: var(--md-admonition-icon--note);
-  -webkit-mask-image: var(--md-admonition-icon--note);
+  mask-image: var(--md-admonition-icon--admonish-note);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-note);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.abstract, .summary, .tldr) {
+:is(.admonition):is(.admonish-abstract, .admonish-summary, .admonish-tldr) {
   border-color: #00b0ff;
 }
 
-:is(.abstract, .summary, .tldr) > :is(.admonition-title, summary) {
+:is(.admonish-abstract, .admonish-summary, .admonish-tldr) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(0, 176, 255, 0.1);
 }
-:is(.abstract, .summary, .tldr) > :is(.admonition-title, summary)::before {
+:is(.admonish-abstract, .admonish-summary, .admonish-tldr) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #00b0ff;
-  mask-image: var(--md-admonition-icon--abstract);
-  -webkit-mask-image: var(--md-admonition-icon--abstract);
+  mask-image: var(--md-admonition-icon--admonish-abstract);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-abstract);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.info, .todo) {
+:is(.admonition):is(.admonish-info, .admonish-todo) {
   border-color: #00b8d4;
 }
 
-:is(.info, .todo) > :is(.admonition-title, summary) {
+:is(.admonish-info, .admonish-todo) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(0, 184, 212, 0.1);
 }
-:is(.info, .todo) > :is(.admonition-title, summary)::before {
+:is(.admonish-info, .admonish-todo) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #00b8d4;
-  mask-image: var(--md-admonition-icon--info);
-  -webkit-mask-image: var(--md-admonition-icon--info);
+  mask-image: var(--md-admonition-icon--admonish-info);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-info);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.tip, .hint, .important) {
+:is(.admonition):is(.admonish-tip, .admonish-hint, .admonish-important) {
   border-color: #00bfa5;
 }
 
-:is(.tip, .hint, .important) > :is(.admonition-title, summary) {
+:is(.admonish-tip, .admonish-hint, .admonish-important) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(0, 191, 165, 0.1);
 }
-:is(.tip, .hint, .important) > :is(.admonition-title, summary)::before {
+:is(.admonish-tip, .admonish-hint, .admonish-important) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #00bfa5;
-  mask-image: var(--md-admonition-icon--tip);
-  -webkit-mask-image: var(--md-admonition-icon--tip);
+  mask-image: var(--md-admonition-icon--admonish-tip);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-tip);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.success, .check, .done) {
+:is(.admonition):is(.admonish-success, .admonish-check, .admonish-done) {
   border-color: #00c853;
 }
 
-:is(.success, .check, .done) > :is(.admonition-title, summary) {
+:is(.admonish-success, .admonish-check, .admonish-done) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(0, 200, 83, 0.1);
 }
-:is(.success, .check, .done) > :is(.admonition-title, summary)::before {
+:is(.admonish-success, .admonish-check, .admonish-done) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #00c853;
-  mask-image: var(--md-admonition-icon--success);
-  -webkit-mask-image: var(--md-admonition-icon--success);
+  mask-image: var(--md-admonition-icon--admonish-success);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-success);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.question, .help, .faq) {
+:is(.admonition):is(.admonish-question, .admonish-help, .admonish-faq) {
   border-color: #64dd17;
 }
 
-:is(.question, .help, .faq) > :is(.admonition-title, summary) {
+:is(.admonish-question, .admonish-help, .admonish-faq) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(100, 221, 23, 0.1);
 }
-:is(.question, .help, .faq) > :is(.admonition-title, summary)::before {
+:is(.admonish-question, .admonish-help, .admonish-faq) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #64dd17;
-  mask-image: var(--md-admonition-icon--question);
-  -webkit-mask-image: var(--md-admonition-icon--question);
+  mask-image: var(--md-admonition-icon--admonish-question);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-question);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.warning, .caution, .attention) {
+:is(.admonition):is(.admonish-warning, .admonish-caution, .admonish-attention) {
   border-color: #ff9100;
 }
 
-:is(.warning, .caution, .attention) > :is(.admonition-title, summary) {
+:is(.admonish-warning, .admonish-caution, .admonish-attention) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(255, 145, 0, 0.1);
 }
-:is(.warning, .caution, .attention) > :is(.admonition-title, summary)::before {
+:is(.admonish-warning, .admonish-caution, .admonish-attention) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #ff9100;
-  mask-image: var(--md-admonition-icon--warning);
-  -webkit-mask-image: var(--md-admonition-icon--warning);
+  mask-image: var(--md-admonition-icon--admonish-warning);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-warning);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.failure, .fail, .missing) {
+:is(.admonition):is(.admonish-failure, .admonish-fail, .admonish-missing) {
   border-color: #ff5252;
 }
 
-:is(.failure, .fail, .missing) > :is(.admonition-title, summary) {
+:is(.admonish-failure, .admonish-fail, .admonish-missing) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(255, 82, 82, 0.1);
 }
-:is(.failure, .fail, .missing) > :is(.admonition-title, summary)::before {
+:is(.admonish-failure, .admonish-fail, .admonish-missing) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #ff5252;
-  mask-image: var(--md-admonition-icon--failure);
-  -webkit-mask-image: var(--md-admonition-icon--failure);
+  mask-image: var(--md-admonition-icon--admonish-failure);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-failure);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.danger, .error) {
+:is(.admonition):is(.admonish-danger, .admonish-error) {
   border-color: #ff1744;
 }
 
-:is(.danger, .error) > :is(.admonition-title, summary) {
+:is(.admonish-danger, .admonish-error) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(255, 23, 68, 0.1);
 }
-:is(.danger, .error) > :is(.admonition-title, summary)::before {
+:is(.admonish-danger, .admonish-error) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #ff1744;
-  mask-image: var(--md-admonition-icon--danger);
-  -webkit-mask-image: var(--md-admonition-icon--danger);
+  mask-image: var(--md-admonition-icon--admonish-danger);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-danger);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.bug) {
+:is(.admonition):is(.admonish-bug) {
   border-color: #f50057;
 }
 
-:is(.bug) > :is(.admonition-title, summary) {
+:is(.admonish-bug) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(245, 0, 87, 0.1);
 }
-:is(.bug) > :is(.admonition-title, summary)::before {
+:is(.admonish-bug) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #f50057;
-  mask-image: var(--md-admonition-icon--bug);
-  -webkit-mask-image: var(--md-admonition-icon--bug);
+  mask-image: var(--md-admonition-icon--admonish-bug);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-bug);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.example) {
+:is(.admonition):is(.admonish-example) {
   border-color: #7c4dff;
 }
 
-:is(.example) > :is(.admonition-title, summary) {
+:is(.admonish-example) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(124, 77, 255, 0.1);
 }
-:is(.example) > :is(.admonition-title, summary)::before {
+:is(.admonish-example) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #7c4dff;
-  mask-image: var(--md-admonition-icon--example);
-  -webkit-mask-image: var(--md-admonition-icon--example);
+  mask-image: var(--md-admonition-icon--admonish-example);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-example);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.quote, .cite) {
+:is(.admonition):is(.admonish-quote, .admonish-cite) {
   border-color: #9e9e9e;
 }
 
-:is(.quote, .cite) > :is(.admonition-title, summary) {
+:is(.admonish-quote, .admonish-cite) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(158, 158, 158, 0.1);
 }
-:is(.quote, .cite) > :is(.admonition-title, summary)::before {
+:is(.admonish-quote, .admonish-cite) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #9e9e9e;
-  mask-image: var(--md-admonition-icon--quote);
-  -webkit-mask-image: var(--md-admonition-icon--quote);
+  mask-image: var(--md-admonition-icon--admonish-quote);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-quote);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
@@ -340,7 +327,8 @@ details[open].admonition > summary.admonition-title::after {
   background-color: var(--sidebar-bg);
 }
 
-.ayu :is(.admonition), .coal :is(.admonition) {
+.ayu :is(.admonition),
+.coal :is(.admonition) {
   background-color: var(--theme-hover);
 }
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -7,6 +7,7 @@
   - [Trusted Dealer Key Generation](tutorial/trusted-dealer.md)
   - [Signing](tutorial/signing.md)
   - [Distributed Key Generation](tutorial/dkg.md)
+  - [Key Resharing](tutorial/resharing.md)
 - [User Documentation](user.md)
   - [Serialization Format](user/serialization.md)
 - [FROST with Zcash](zcash.md)

--- a/book/src/tutorial/resharing.md
+++ b/book/src/tutorial/resharing.md
@@ -1,0 +1,124 @@
+# Key Resharing
+
+_Resharing_ is the process of dynamically re-generating the shares of a FROST signing group, without recovering the group's master private key. This is effectively like repeating [the Distributed Key Generation process](./dkg.html) so that new shares are distributed to each signer, except the group **retains the same group verifying key.** Signers can verify their new shares are valid for the same group verifying key, and any invalid contributions can be identified just like during a FROST signing session.
+
+In so doing, signing groups can achieve a number of interesting use cases:
+
+- [Revoking exposed shares](#revoking-exposed-shares)
+- Protection against [Mobile Adversaries](#mobile-adversaries)
+- [Changing the signing group and threshold](#changing-the-group-and-threshold)
+
+## Revoking Exposed Shares
+
+Consider a case where one FROST signer's share was accidentally exposed publicly - For example, published on social media, or revealed through secret nonce reuse. The group's signing/security threshold will have decreased by one share (since the exposed share is known to everyone). The signing group would probably want some way to revoke that share, and optionally issue a new share to the signer who exposed their share, thereby recovering their group's desired security properties.
+
+_Resharing_ provides a simple mechanism which accomplishes this. Every time the resharing protocol is executed, the signers overwrite their old signing shares with new shares which are _incompatible_ with their old ones. Assuming the other signers' shares remained secret until they were erased, the exposed share is now unusable.
+
+### Example
+
+Consider a 3-of-4 threshold signing group: Alice, Bob, Carol, and Dave, with shares `a1`, `b1`, `c1`, and `d1` respectively.
+
+```
+┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐
+│    Alice   │  │    Bob     │  │   Carol    │  │    Dave    │
+│ ┌────────┐ │  │ ┌────────┐ │  │ ┌────────┐ │  │ ┌────────┐ │
+│ │share_a1│ │  │ │share_b1│ │  │ │share_c1│ │  │ │share_d1│ │
+│ └────────┘ │  │ └────────┘ │  │ └────────┘ │  │ └────────┘ │
+└────────────┘  └────────────┘  └────────────┘  └────────────┘
+```
+
+Bob exposes his share `b1` by posting it to his MySpace page. How silly of Bob. Now his share `b1` is known by every other signer, and by the rest of the internet at large.
+
+```
+┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐
+│    Alice   │  │    Bob     │  │   Carol    │  │    Dave    │
+│ ┌────────┐ │  │ ┌────────┐ │  │ ┌────────┐ │  │ ┌────────┐ │
+│ │share_a1│ │  │ │share_b1│ │  │ │share_c1│ │  │ │share_d1│ │
+│ └────────┘ │  │ └────────┘ │  │ └────────┘ │  │ └────────┘ │
+└────────────┘  └────────────┘  └────────────┘  └────────────┘
+
+           ┌──────────────────────────────────────┐
+           │           Public Knowledge           │
+           │             ┌────────┐               │
+           │             │share_b1│               │
+           │             └────────┘               │
+           └──────────────────────────────────────┘
+```
+
+The signers agree to execute a resharing procedure, and issue Bob a new share in the process. Since Bob's `b1` share is public now, only a minimum of 2 out of the 4 signers need to be online and available to execute the resharing, but for practical reasons, it is best for all signers to participate.
+
+This process results in four new shares, `a2`, `b2`, `c2`, and `d2` distributed to Alice, Bob, Carol and Dave respectively. These shares are **incompatible** with the four original shares `[a1, b1, c1, d1]`. Shares from different key-generation or resharing runs **cannot** be used together. For instance, the set of shares `[a2, b1, c2]` would **not** be sufficient to sign on behalf of the FROST group.
+
+Upon receiving their new shares and acknowledging their validity, signers securely erase the old shares. This step is important but unfortunately not verifiable. Nothing prevents signers from keeping their old shares. If everyone behaves honestly though, the exposed share `b1` is rendered useless, because the other three shares `a1`, `c1`, and `d1` are now permanently erased and unknowable.
+
+```
+┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐
+│    Alice   │  │    Bob     │  │   Carol    │  │    Dave    │
+│ ┌────────┐ │  │ ┌────────┐ │  │ ┌────────┐ │  │ ┌────────┐ │
+│ │xxxxxxxx│ │  │ │xxxxxxxx│ │  │ │xxxxxxxx│ │  │ │xxxxxxxx│ │
+│ └────────┘ │  │ └────────┘ │  │ └────────┘ │  │ └────────┘ │
+│ ┌────────┐ │  │ ┌────────┐ │  │ ┌────────┐ │  │ ┌────────┐ │
+│ │share_a2│ │  │ │share_b2│ │  │ │share_c2│ │  │ │share_d2│ │
+│ └────────┘ │  │ └────────┘ │  │ └────────┘ │  │ └────────┘ │
+└────────────┘  └────────────┘  └────────────┘  └────────────┘
+
+           ┌──────────────────────────────────────┐
+           │           Public Knowledge           │
+           │             ┌────────┐               │
+           │             │share_b1│ <--- useless  │
+           │             └────────┘               │
+           └──────────────────────────────────────┘
+```
+
+## Mobile Adversaries
+
+A _mobile adversary_ is a hypothetical term denoting an attacker who _corrupts_ some fraction of signers _slowly over time,_ such as by infecting their computers with a virus which only spreads to one signer at a time. However, a corrupted signer is not guaranteed to _stay_ corrupted. They might realize their system is infected and change over to a new computer, or they might reinstall their operating system.
+
+As time goes on, the mobile adversary can _corrupt_ more of the signing group. Although some signers might _un-corrupt_ themselves, the adversary has still learned their secret share through the virus, and thus inches closer to breaking the security threshold `t` of the signing group. Once the adversary has corrupted `t` signers at least once, they have learned enough shares to sign arbitrary messages on behalf of the group.
+
+_Resharing_ allows a signing group to defend themselves against mobile adversaries. By resharing on a regular basis, the group ensures any shares exposed to mobile adversaries are revoked. The adversary must then corrupt `t` or more signers _all at once,_ which is much harder. Provided the group executes the resharing protocol frequently enough, and signers overwrite their old signing shares each time, the mobile adversary will have a much harder time learning enough compatible shares to effectively attack the group.
+
+## Changing the Group and Threshold
+
+The recipients of shares from a resharing execution do not necessarily need to be the same as the original group of signers. It is possible for resharing to be used to intentionally exclude certain members of the signing group by effectively revoking their shares.
+
+Equally, resharing can be used to add new signers into the group. Although if the group only wants to _add_ new members without removing any old signers, then using _repairable secret sharing_ is probably a simpler approach.
+
+Perhaps most interestingly though, resharing allows the participants to decide on a new _group signing threshold_ which applies to the newly issued shares. Threshold modification has some gotchas though. The new threshold, denoted `t'`, only applies to the shares issued by the relevant resharing execution. The old shares from before the resharing are still valid and retain the old threshold, denoted `t`. Unless deleted, they could still be used together.
+
+Thus, using resharing to modify the threshold should be used cautiously, and with the assumption that signers _could_ choose to retain their old shares. Reducing `t` is generally less problematic than increasing it, because new shares with a lower threshold will carry more signing power than old shares, and so signers have less incentive to retain the old shares.
+
+# A Resharing Run
+
+Resharing is split into three logical steps:
+
+1. Broadcast commitment
+2. Send subshares
+3. Reconstruct new share
+4. (optional) ACK and delete old share
+
+## Broadcast Commitment
+
+A public commitment must be sent over a [**broadcast channel**](/terminology.html#broadcast-channel) to all the recipient peers, who will be part of the new group after resharing.
+
+## Send Subshares
+
+Subshares, which one could think of as "shares-of-a-share", are sent to the recipients over [an authenticated & confidential channel](/terminology.html#peer-to-peer-channel).
+
+## Reconstruct New Share
+
+The recipients receive commitments and subshares from the resharers. They can verify each subshare is consistent with its sender's commitment, and also compute a new signing share from the subshares.
+
+If the recipient knows the public verifying key of the group they are joining, the recipient can verify the resulting share they reconstructed is valid for that group key.
+
+If the recipient knows the public verifying _shares_ of the individual resharers, they can assign blame to any resharer who may have provided them with an invalid subshare and commitment pair.
+
+## (optional) ACK and Delete Old Share
+
+Once all recipients have acknowledged they received and reconstructed a new set of valid signing shares, then the resharers can erase their old signing shares.
+
+```admonish danger
+It is important that all recipients acknowledge successful resharing before any signing shares are erased. Premature share erasure can result in a ['Forget-and-Forgive'](https://iacr.org/submit/files/slides/2021/rwc/rwc2021/31/slides.pdf) attack, where a single malicious signer can convince some of the group to overwrite their old shares by giving providing valid subshares, but block others from finishing the procedure by providing them with _invalid_ subshares.
+
+This attack _splits_ the group in two: Those who have _new_ shares and those who have _old_ shares. If `t > n/2` (i.e. if the threshold is greater than half the group size), this results in a deadlock where not enough compatible signing shares exist anymore for the group to recover.
+```

--- a/frost-core/src/keys.rs
+++ b/frost-core/src/keys.rs
@@ -28,6 +28,7 @@ use super::compute_lagrange_coefficient;
 
 pub mod dkg;
 pub mod repairable;
+pub mod resharing;
 
 /// Sum the commitments from all participants in a distributed key generation
 /// run into a single group commitment.

--- a/frost-core/src/keys/repairable.rs
+++ b/frost-core/src/keys/repairable.rs
@@ -107,7 +107,7 @@ pub fn repair_share_step_2<C: Ciphersuite>(deltas_j: &[Scalar<C>]) -> Scalar<C> 
 /// Step 3 of RTS
 ///
 /// The `participant` sums all `sigma_j` received to compute the `share`. The `SecretShare`
-/// is made up of the `identifier`and `commitment` of the `participant` as well as the
+/// is made up of the `identifier` and `commitment` of the `participant` as well as the
 /// `value` which is the `SigningShare`.
 pub fn repair_share_step_3<C: Ciphersuite>(
     sigmas: &[Scalar<C>],

--- a/frost-core/src/keys/resharing.rs
+++ b/frost-core/src/keys/resharing.rs
@@ -1,0 +1,222 @@
+//! Dynamic resharing of FROST signing keys.
+//!
+//! Implements [Wang's Verifiable Secret Resharing (VSR) Scheme
+#![doc = "](https://www.semanticscholar.org/paper/Verifiable-Secret-Redistribution\
+-for-Threshold-Wong-Wang/48d248779002b0015bdb99841a43395b526d5f8e)."]
+//! FROST signing shares can be periodically rotated among signers to
+//! protect against mobile and active adversaries. This allows old shares
+//! to be 'revoked' (although only in a soft manner) and replaced with new shares.
+//!
+//! As a byproduct, resharing allows signers to change parameters of their
+//! signing group, including setting a new threshold, changing identifiers,
+//! adding new signers or excluding old signers from the new group of shares.
+//! Resharing can be done even if some signers are offline; as long as the
+//! signing threshold is met, the joint secret can be redistributed with new
+//! shares and potentially a new threshold.
+//!
+//! Shares issued from before and after the resharing are mutually incompatible,
+//! so it is imperative that at least the one threshold-subset of signers ACK
+//! the resharing as successful before anyone deletes their old shares. See
+//! [`reshare_step_2`] for more info.
+//!
+//! After a resharing occurs, the old shares are still usable. Normally, signers
+//! are advised to delete their old shares, but nothing prevents them from keeping
+//! the outdated shares either by maliciousness or through honest mistake.
+//!
+//! Downstream consumers should consider how inactive signers will be notified
+//! about a resharing which occurrs while they are offline.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{
+    compute_lagrange_coefficient, Ciphersuite, CryptoRng, Error, Field, Group, Identifier, RngCore,
+    Scalar,
+};
+
+use super::{
+    evaluate_vss, split, validate_num_of_signers, CoefficientCommitment, IdentifierList,
+    KeyPackage, PublicKeyPackage, SecretShare, SigningKey, SigningShare,
+    VerifiableSecretSharingCommitment, VerifyingShare,
+};
+
+/// A subshare of a secret share. This contains the same data
+/// as a [`SecretShare`], except it is actually a share of a share,
+/// used in the process of resharing.
+pub type SecretSubshare<C> = SecretShare<C>;
+
+/// Split a secret signing share into a set of secret subshares (shares of a share).
+///
+/// `share_i` is our FROST signing share, which will be split into subshares.
+///
+/// `new_threshold` is the desired new minimum signer threshold after resharing.
+/// All signers participating in resharing must specify the same `new_threshold`.
+///
+/// `new_idents` is a list of identifiers for peers to whom the secret subshares
+/// will be distributed. Depending on use-case, these identifiers may be completely
+/// new, or they may be the same as the old signing group from before resharing.
+///
+/// The resulting output maps peers' identifiers to the subshare which they should
+/// receive. The commitment in each subshare is the same, and should be broadcast
+/// to all subshare recipients. The secret subshare itself should be sent via
+/// a private authenticated channel to the specific recipient which maps to it.
+pub fn reshare_step_1<C: Ciphersuite, R: RngCore + CryptoRng>(
+    share_i: &SigningShare<C>,
+    rng: &mut R,
+    new_threshold: u16,
+    new_idents: &[Identifier<C>],
+) -> Result<BTreeMap<Identifier<C>, SecretSubshare<C>>, Error<C>> {
+    let (subshares, _) = split(
+        &SigningKey::from_scalar(share_i.0),
+        new_idents.len() as u16,
+        new_threshold,
+        IdentifierList::Custom(new_idents),
+        rng,
+    )?;
+
+    Ok(subshares)
+}
+
+/// Verify and combine a set of secret subshares into a new FROST signing share.
+///
+/// `our_ident` is the identifier for ourself.
+///
+/// `old_pubkeys` is the old public key package for the group's joint FROST key.
+///
+/// `new_threshold` is the desired new minimum signer threshold after resharing.
+/// All signers participating in resharing must specify the same `new_threshold`.
+///
+/// `new_idents` is the list of identifiers for peers to whom the secret subshares
+/// are being distributed. Depending on use-case, these identifiers may be completely
+/// new, or they may be the same as the old signing group from before resharing.
+///
+/// `received_subshares` maps identifiers to the secret subshare sent by those peers.
+/// We assume the commitment in each subshare is consistent with a commitment publicly
+/// broadcasted by the sender, i.e. we assume each peer has not equivocated by sending
+/// inconsistent commitments to different subshare recipients.
+///
+/// The output is a new FROST secret signing share and public key package. The joint
+/// public key will match the old joint public key, but the signing and verification
+/// shares will be changed and will no longer be compatible with old shares from
+/// before the resharing occurred.
+///
+/// The caller MUST ensure at least `new_threshold` signers ACK the resharing as successful.
+/// We recommend having each signer broadcast their public verification shares to confirm
+/// the new set of shares are all consistent. Only then can the previous shares be safely
+/// overwritten.
+pub fn reshare_step_2<C: Ciphersuite>(
+    our_ident: Identifier<C>,
+    old_pubkeys: &PublicKeyPackage<C>,
+    new_threshold: u16,
+    new_idents: &[Identifier<C>],
+    received_subshares: &BTreeMap<Identifier<C>, SecretSubshare<C>>,
+) -> Result<(KeyPackage<C>, PublicKeyPackage<C>), Error<C>> {
+    validate_num_of_signers(new_threshold, new_idents.len() as u16)?;
+    for (sender_ident, subshare) in received_subshares.into_iter() {
+        // Ensure each subshare is from a member of the group.
+        let verifying_share = old_pubkeys
+            .verifying_shares
+            .get(sender_ident)
+            .ok_or(Error::UnknownIdentifier)?;
+
+        // Constant term of the commitment MUST be the same as the sender's own
+        // public share. If this fails, the `old_pubkeys` is internally inconsistent.
+        if subshare.commitment.coefficients()[0].value() != verifying_share.to_element() {
+            return Err(Error::IncorrectCommitment)?; // TODO add culprit
+        }
+
+        // Every peer's resharing polynomial must have degree `t' - 1`.
+        if subshare.commitment.coefficients().len() != new_threshold as usize {
+            return Err(Error::InvalidCoefficients); // TODO add culprit
+        }
+    }
+
+    let old_idents: BTreeSet<Identifier<C>> = received_subshares.keys().copied().collect();
+    let lagrange_coefficients: BTreeMap<Identifier<C>, Scalar<C>> = old_idents
+        .iter()
+        .map(|&id| -> Result<(Identifier<C>, Scalar<C>), Error<C>> {
+            let l = compute_lagrange_coefficient(&old_idents, None, id)?;
+            Ok((id, l))
+        })
+        .collect::<Result<_, Error<C>>>()?;
+
+    let group_pubkey = received_subshares
+        .into_iter()
+        .map(|(id, subshare)| {
+            subshare.commitment.coefficients()[0].value() * lagrange_coefficients[id]
+        })
+        .reduce(|sum, term| sum + term)
+        .ok_or(Error::IncorrectNumberOfShares)?; // At least one subshare is required.
+
+    // The pubkeys participating in resharing must represent at least the old
+    // threshold `t` of the group. The interpolated pubkey will not match here
+    // unless that threshold is met.
+    if group_pubkey != old_pubkeys.verifying_key.to_element() {
+        return Err(Error::IncorrectNumberOfShares);
+    }
+
+    let mut new_share_sum = <C::Group as Group>::Field::zero();
+
+    for (sender_ident, subshare) in received_subshares.into_iter() {
+        // Verify the subshare against the commitment.
+        //   s_{ij} * G == G * ( s_i + a_1*j + a_2 * j^2 + ... + a_{t'-1} * j^{t'-1} )
+        let s = subshare.signing_share.to_scalar();
+        if C::Group::generator() * s != evaluate_vss(our_ident, &subshare.commitment) {
+            return Err(Error::InvalidSecretShare); // TODO add culprit
+        }
+
+        // The new share is computed by interpolating the constant coefficient of a
+        // new polynomial generated jointly by the signers who participated in resharing.
+        new_share_sum = new_share_sum + s * lagrange_coefficients[sender_ident];
+    }
+
+    let new_signing_share = SigningShare(new_share_sum);
+
+    // The group's new public polynomial coefficients can be computed by treating commitment
+    // coefficients as polynomial evaluations and interpolating the resulting function.
+    // See Step 8 here: https://conduition.io/cryptography/shamir-resharing/#Resharing
+    let new_group_commit_coeffs: Vec<CoefficientCommitment<C>> = (0..new_threshold as usize)
+        .map(|k| {
+            received_subshares
+                .iter()
+                .fold(C::Group::identity(), |sum, (id, subshare)| {
+                    sum + subshare.commitment.coefficients()[k].value() * lagrange_coefficients[id]
+                })
+        })
+        .map(CoefficientCommitment)
+        .collect();
+
+    // The new group commitment should match the group pubkey.
+    if new_group_commit_coeffs[0].value() != old_pubkeys.verifying_key.to_element() {
+        return Err(Error::IncorrectCommitment);
+    }
+
+    let new_group_commitment = VerifiableSecretSharingCommitment(new_group_commit_coeffs);
+
+    let new_verifying_shares: BTreeMap<Identifier<C>, VerifyingShare<C>> = new_idents
+        .into_iter()
+        .map(|&id| (id, VerifyingShare(evaluate_vss(id, &new_group_commitment))))
+        .collect();
+
+    // Our identifier must be one of the intended resharing recipients.
+    let new_verifying_share = new_verifying_shares
+        .get(&our_ident)
+        .ok_or(Error::UnknownIdentifier)?
+        .clone();
+
+    // Sanity check; our new share should be valid for the new commitment.
+    if C::Group::generator() * new_share_sum != new_verifying_share.to_element() {
+        return Err(Error::InvalidSecretShare);
+    }
+
+    let new_pubkey_pkg = PublicKeyPackage::new(new_verifying_shares, old_pubkeys.verifying_key);
+
+    let new_secret_key_package = KeyPackage::new(
+        our_ident,
+        new_signing_share,
+        new_verifying_share,
+        old_pubkeys.verifying_key,
+        new_threshold,
+    );
+
+    Ok((new_secret_key_package, new_pubkey_pkg))
+}

--- a/frost-core/src/tests.rs
+++ b/frost-core/src/tests.rs
@@ -8,5 +8,6 @@ pub mod coefficient_commitment;
 pub mod helpers;
 pub mod proptests;
 pub mod repairable;
+pub mod resharing;
 pub mod vectors;
 pub mod vss_commitment;

--- a/frost-core/src/tests/resharing.rs
+++ b/frost-core/src/tests/resharing.rs
@@ -1,0 +1,145 @@
+//! Test for Verifiable Secret Redistribution (AKA resharing).
+
+use std::collections::BTreeMap;
+
+use rand_core::{CryptoRng, RngCore};
+
+use crate as frost;
+use crate::{
+    keys::{
+        resharing::{reshare_step_1, reshare_step_2, SecretSubshare},
+        PublicKeyPackage, SecretShare,
+    },
+    Ciphersuite, Identifier,
+};
+
+/// Check correctness of the verifiable secret redistribution protocol.
+pub fn check_vsr<C: Ciphersuite, R: RngCore + CryptoRng>(mut rng: R) {
+    // Generate old keys and shares.
+    let max_signers = 5;
+    let old_min_signers = 3;
+    let (old_shares, old_pubkeys): (BTreeMap<Identifier<C>, SecretShare<C>>, PublicKeyPackage<C>) =
+        frost::keys::generate_with_dealer(
+            max_signers,
+            old_min_signers,
+            frost::keys::IdentifierList::Default,
+            &mut rng,
+        )
+        .unwrap();
+
+    // Signer 1, 2, and 4 will participate in resharing.
+    let helper_1 = &old_shares[&Identifier::try_from(1).unwrap()];
+    let helper_2 = &old_shares[&Identifier::try_from(2).unwrap()];
+    let helper_4 = &old_shares[&Identifier::try_from(4).unwrap()];
+
+    // They will reshare the key amongst themselves, plus new signer 5.
+    // Signer 3 will be excluded.
+    let new_signer_5_ident = Identifier::try_from(5).unwrap();
+    let new_signer_idents = [
+        helper_1.identifier,
+        helper_2.identifier,
+        helper_4.identifier,
+        new_signer_5_ident,
+    ];
+
+    // The threshold will be changed from 3 to 2.
+    let new_min_signers = 2;
+
+    // Each helper generates their random coefficients and commitments.
+    let helper_1_subshares = reshare_step_1(
+        &helper_1.signing_share,
+        &mut rng,
+        new_min_signers,
+        &new_signer_idents,
+    )
+    .expect("error computing resharing step 1 for helper 1");
+
+    let helper_2_subshares = reshare_step_1(
+        &helper_2.signing_share,
+        &mut rng,
+        new_min_signers,
+        &new_signer_idents,
+    )
+    .expect("error computing resharing step 1 for helper 2");
+
+    let helper_4_subshares = reshare_step_1(
+        &helper_4.signing_share,
+        &mut rng,
+        new_min_signers,
+        &new_signer_idents,
+    )
+    .expect("error computing resharing step 1 for helper 4");
+
+    let all_subshares = BTreeMap::from([
+        (helper_1.identifier, helper_1_subshares),
+        (helper_2.identifier, helper_2_subshares),
+        (helper_4.identifier, helper_4_subshares),
+    ]);
+
+    // Sort the subshares into a map of `recipient => sender => subshare`.
+    let received_subshares = new_signer_idents
+        .into_iter()
+        .map(|recipient_id| {
+            let received_subshares = all_subshares
+                .iter()
+                .map(|(&sender_id, sender_shares)| {
+                    (sender_id, sender_shares[&recipient_id].clone())
+                })
+                .collect::<BTreeMap<_, _>>();
+            (recipient_id, received_subshares)
+        })
+        .collect::<BTreeMap<Identifier<C>, BTreeMap<Identifier<C>, SecretSubshare<C>>>>();
+
+    // Recipients of the resharing can now validate and compute their new shares.
+
+    let (new_seckeys_1, new_pubkeys_1) = reshare_step_2(
+        helper_1.identifier,
+        &old_pubkeys,
+        new_min_signers,
+        &new_signer_idents,
+        &received_subshares[&helper_1.identifier],
+    )
+    .expect("error computing reshared share for signer 1");
+
+    let (new_seckeys_2, new_pubkeys_2) = reshare_step_2(
+        helper_2.identifier,
+        &old_pubkeys,
+        new_min_signers,
+        &new_signer_idents,
+        &received_subshares[&helper_2.identifier],
+    )
+    .expect("error computing reshared share for signer 2");
+
+    let (new_seckeys_4, new_pubkeys_4) = reshare_step_2(
+        helper_4.identifier,
+        &old_pubkeys,
+        new_min_signers,
+        &new_signer_idents,
+        &received_subshares[&helper_4.identifier],
+    )
+    .expect("error computing reshared share for signer 4");
+
+    let (new_seckeys_5, new_pubkeys_5) = reshare_step_2(
+        new_signer_5_ident,
+        &old_pubkeys,
+        new_min_signers,
+        &new_signer_idents,
+        &received_subshares[&new_signer_5_ident],
+    )
+    .expect("error computing reshared share for signer 5");
+
+    // all signers should compute the same group pubkeys.
+    assert_eq!(new_pubkeys_1, new_pubkeys_2);
+    assert_eq!(new_pubkeys_1, new_pubkeys_4);
+    assert_eq!(new_pubkeys_1, new_pubkeys_5);
+    assert_eq!(new_seckeys_1.verifying_key, new_seckeys_2.verifying_key);
+    assert_eq!(new_seckeys_1.verifying_key, new_seckeys_4.verifying_key);
+    assert_eq!(new_seckeys_1.verifying_key, new_seckeys_5.verifying_key);
+
+    // The new pubkey package should be the same group key as the old one,
+    // but with new coefficients and shares.
+    assert_eq!(new_pubkeys_1.verifying_key, old_pubkeys.verifying_key);
+    assert_ne!(new_pubkeys_1.verifying_shares, old_pubkeys.verifying_shares);
+
+    assert_eq!(new_seckeys_1.min_signers, new_min_signers);
+}

--- a/frost-ristretto255/src/keys/resharing.rs
+++ b/frost-ristretto255/src/keys/resharing.rs
@@ -1,0 +1,38 @@
+//! TODO
+
+use std::collections::BTreeMap;
+
+use crate::Error;
+use crate::{frost, CryptoRng, Identifier, RngCore};
+
+use super::{KeyPackage, PublicKeyPackage, SecretShare, SigningShare};
+
+/// TODO
+pub type SecretSubshare = SecretShare;
+
+/// TODO
+pub fn reshare_step_1<R: RngCore + CryptoRng>(
+    share_i: &SigningShare,
+    rng: &mut R,
+    new_threshold: u16,
+    new_idents: &[Identifier],
+) -> Result<BTreeMap<Identifier, SecretSubshare>, Error> {
+    frost::keys::resharing::reshare_step_1(share_i, rng, new_threshold, new_idents)
+}
+
+/// TODO
+pub fn reshare_step_2(
+    our_ident: Identifier,
+    old_pubkeys: &PublicKeyPackage,
+    new_threshold: u16,
+    new_idents: &[Identifier],
+    received_subshares: &BTreeMap<Identifier, SecretSubshare>,
+) -> Result<(KeyPackage, PublicKeyPackage), Error> {
+    frost::keys::resharing::reshare_step_2(
+        our_ident,
+        old_pubkeys,
+        new_threshold,
+        new_idents,
+        received_subshares,
+    )
+}

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -306,6 +306,7 @@ pub mod keys {
 
     pub mod dkg;
     pub mod repairable;
+    pub mod resharing;
 }
 
 /// FROST(ristretto255, SHA-512) Round 1 functionality and types.

--- a/frost-ristretto255/tests/integration_tests.rs
+++ b/frost-ristretto255/tests/integration_tests.rs
@@ -65,6 +65,15 @@ fn check_rts() {
 }
 
 #[test]
+fn check_vsr() {
+    // let rng = thread_rng();
+    use rand::SeedableRng;
+    let rng = rand::rngs::StdRng::seed_from_u64(0);
+
+    frost_core::tests::resharing::check_vsr::<Ristretto255Sha512, _>(rng);
+}
+
+#[test]
 fn check_sign_with_dealer() {
     let rng = thread_rng();
 


### PR DESCRIPTION
This PR implements Wang's Verifiable Secret Redistribution (VSR) Scheme to allow resharing of FROST shares, with protection against active adversaries. See https://github.com/ZcashFoundation/frost/issues/519 for research and justification. Also see https://github.com/ZcashFoundation/frost/issues/245 for related work.

This enables threshold modification, signer identifier changes, share revocation, and other cool downstream use-cases. 

This PR is not complete; i wanted to check in and get feedback before proceeding further. 

Remaining work:

- [ ] More thorough integration tests
- [ ] Implement the `resharing` module in all `frost-*` ciphersuite crates.
- [ ] Improve documentation.
- [x] Add docs to the book.
- [ ] Other things I'm missing? 

