### PR TITLE
re-export serde in ciphersuite crates

### DIFF
--- a/frost-core/CHANGELOG.md
+++ b/frost-core/CHANGELOG.md
@@ -22,6 +22,7 @@ Entries are listed in reverse chronological order.
 * Added `PublicKeyPackage::from_commitment()` and
   `PublicKeyPackage::from_dkg_commitments` to create a `PublicKeyPackage` from
   the commitments generated in trusted dealer or distributed key generation.
+* Ciphersuite crates now re-export `serde` if enabled.
 
 ## Released
 

--- a/frost-ed25519/src/lib.rs
+++ b/frost-ed25519/src/lib.rs
@@ -23,7 +23,7 @@ use frost_core as frost;
 mod tests;
 
 // Re-exports in our public API
-pub use frost_core::{Ciphersuite, Field, FieldError, Group, GroupError};
+pub use frost_core::{serde, Ciphersuite, Field, FieldError, Group, GroupError};
 pub use rand_core;
 
 /// An error.

--- a/frost-ed448/src/lib.rs
+++ b/frost-ed448/src/lib.rs
@@ -24,7 +24,7 @@ use frost_core as frost;
 mod tests;
 
 // Re-exports in our public API
-pub use frost_core::{Ciphersuite, Field, FieldError, Group, GroupError};
+pub use frost_core::{serde, Ciphersuite, Field, FieldError, Group, GroupError};
 pub use rand_core;
 
 /// An error.

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -25,7 +25,7 @@ use frost_core as frost;
 mod tests;
 
 // Re-exports in our public API
-pub use frost_core::{Ciphersuite, Field, FieldError, Group, GroupError};
+pub use frost_core::{serde, Ciphersuite, Field, FieldError, Group, GroupError};
 pub use rand_core;
 
 /// An error.

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -20,7 +20,7 @@ use frost_core as frost;
 mod tests;
 
 // Re-exports in our public API
-pub use frost_core::{Ciphersuite, Field, FieldError, Group, GroupError};
+pub use frost_core::{serde, Ciphersuite, Field, FieldError, Group, GroupError};
 pub use rand_core;
 
 /// An error.

--- a/frost-secp256k1/src/lib.rs
+++ b/frost-secp256k1/src/lib.rs
@@ -26,7 +26,7 @@ use frost_core as frost;
 mod tests;
 
 // Re-exports in our public API
-pub use frost_core::{Ciphersuite, Field, FieldError, Group, GroupError};
+pub use frost_core::{serde, Ciphersuite, Field, FieldError, Group, GroupError};
 pub use rand_core;
 
 /// An error.


### PR DESCRIPTION
Small cleanup. While working on the demo noticed that we missed this. (Reexporting makes it easier for callers to use the same serde library that our crates use, without having to import it again and figuring out which version to import)