### PR TITLE
build and test each crate separately

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,15 +38,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.66.1
       - run: cargo build --all-features
 
-  build_all_features:
-    name: build with all features combinations
+  test_all_features:
+    name: test all features combinations
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4.1.7
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo install cargo-all-features
-      - run: cargo build-all-features
+      # We check and then test because some test dependencies could help
+      # a bugged build work, while a regular build would fail.
+      - run: cargo check-all-features --release
+      # Note that this also tests each crate separately, which also helps
+      # catching some issues.
+      - run: cargo test-all-features --release
 
   test_beta:
     name: test on beta

--- a/frost-core/Cargo.toml
+++ b/frost-core/Cargo.toml
@@ -43,6 +43,7 @@ serde_json = { version = "1.0", optional = true }
 criterion = { version = "0.5", optional = true }
 
 [dev-dependencies]
+criterion = { version = "0.5" }
 lazy_static = "1.4"
 proptest = "1.0"
 rand = "0.8"


### PR DESCRIPTION
`cargo test -p frost-core` was failing because the benchmark was failing to build, which in turn was being caused by the `criterion` dependency not being included when compiling without features.

This was not being caught because on CI we just use `cargo test`, which merges all features and would end up including `criterion`.

This was also not being caught by the all-features test because we were only doing `build` (which does not build benchmarks) and not `test` (which does build benchmarks).

This fixes the issue, and adds test-all-features to CI, which already works on each crate separately.