### PR TITLE
chore(docs): fix clippy warnings in examples

### DIFF
--- a/frost-ed25519/README.md
+++ b/frost-ed25519/README.md
@@ -45,14 +45,14 @@ let mut commitments_map = BTreeMap::new();
 ////////////////////////////////////////////////////////////////////////////
 
 // In practice, each iteration of this loop will be executed by its respective participant.
-for participant_index in 1..(min_signers as u16 + 1) {
+for participant_index in 1..=min_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
     let key_package = &key_packages[&participant_identifier];
     // Generate one (1) nonce and one SigningCommitments instance for each
     // participant, up to _threshold_.
     # // ANCHOR: round1_commit
     let (nonces, commitments) = frost::round1::commit(
-        key_packages[&participant_identifier].signing_share(),
+        key_package.signing_share(),
         &mut rng,
     );
     # // ANCHOR_END: round1_commit

--- a/frost-ed448/README.md
+++ b/frost-ed448/README.md
@@ -45,14 +45,14 @@ let mut commitments_map = BTreeMap::new();
 ////////////////////////////////////////////////////////////////////////////
 
 // In practice, each iteration of this loop will be executed by its respective participant.
-for participant_index in 1..(min_signers as u16 + 1) {
+for participant_index in 1..=min_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
     let key_package = &key_packages[&participant_identifier];
     // Generate one (1) nonce and one SigningCommitments instance for each
     // participant, up to _threshold_.
     # // ANCHOR: round1_commit
     let (nonces, commitments) = frost::round1::commit(
-        key_packages[&participant_identifier].signing_share(),
+        key_package.signing_share(),
         &mut rng,
     );
     # // ANCHOR_END: round1_commit

--- a/frost-p256/README.md
+++ b/frost-p256/README.md
@@ -45,14 +45,14 @@ let mut commitments_map = BTreeMap::new();
 ////////////////////////////////////////////////////////////////////////////
 
 // In practice, each iteration of this loop will be executed by its respective participant.
-for participant_index in 1..(min_signers as u16 + 1) {
+for participant_index in 1..=min_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
     let key_package = &key_packages[&participant_identifier];
     // Generate one (1) nonce and one SigningCommitments instance for each
     // participant, up to _threshold_.
     # // ANCHOR: round1_commit
     let (nonces, commitments) = frost::round1::commit(
-        key_packages[&participant_identifier].signing_share(),
+        key_package.signing_share(),
         &mut rng,
     );
     # // ANCHOR_END: round1_commit

--- a/frost-ristretto255/README.md
+++ b/frost-ristretto255/README.md
@@ -45,14 +45,14 @@ let mut commitments_map = BTreeMap::new();
 ////////////////////////////////////////////////////////////////////////////
 
 // In practice, each iteration of this loop will be executed by its respective participant.
-for participant_index in 1..(min_signers as u16 + 1) {
+for participant_index in 1..=min_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
     let key_package = &key_packages[&participant_identifier];
     // Generate one (1) nonce and one SigningCommitments instance for each
     // participant, up to _threshold_.
     # // ANCHOR: round1_commit
     let (nonces, commitments) = frost::round1::commit(
-        key_packages[&participant_identifier].signing_share(),
+        key_package.signing_share(),
         &mut rng,
     );
     # // ANCHOR_END: round1_commit

--- a/frost-secp256k1/README.md
+++ b/frost-secp256k1/README.md
@@ -45,14 +45,14 @@ let mut commitments_map = BTreeMap::new();
 ////////////////////////////////////////////////////////////////////////////
 
 // In practice, each iteration of this loop will be executed by its respective participant.
-for participant_index in 1..(min_signers as u16 + 1) {
+for participant_index in 1..=min_signers {
     let participant_identifier = participant_index.try_into().expect("should be nonzero");
     let key_package = &key_packages[&participant_identifier];
     // Generate one (1) nonce and one SigningCommitments instance for each
     // participant, up to _threshold_.
     # // ANCHOR: round1_commit
     let (nonces, commitments) = frost::round1::commit(
-        key_packages[&participant_identifier].signing_share(),
+        key_package.signing_share(),
         &mut rng,
     );
     # // ANCHOR_END: round1_commit


### PR DESCRIPTION
- simplify range expression
- use `key_package` variable
