### PR TITLE
ci: pin nightly toolchain when using minimal-versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,8 +30,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4.1.7
-      # Re-resolve Cargo.lock with minimal versions
-      - uses: dtolnay/rust-toolchain@nightly
+      # Re-resolve Cargo.lock with minimal versions.
+      # This only works with nightly. We pin to a specific version because
+      # newer versions use lock file version 4, but the MSRV cargo does not
+      # support that.
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-09-20
       - run: cargo update -Z minimal-versions
       # Now check that `cargo build` works with respect to the oldest possible
       # deps and the stated MSRV


### PR DESCRIPTION
See comment in the yml file