### PR TITLE
chore(frost-core): fix dead_code warning

### DIFF
--- a/frost-core/src/lib.rs
+++ b/frost-core/src/lib.rs
@@ -634,6 +634,7 @@ where
 
 /// Optional cheater detection feature
 /// Each share is verified to find the cheater
+#[cfg(feature = "cheater-detection")]
 fn detect_cheater<C: Ciphersuite>(
     group_commitment: GroupCommitment<C>,
     pubkeys: &keys::PublicKeyPackage<C>,


### PR DESCRIPTION
This PR fixes dead_code warning. I get this error when reusing frost-core in roast-core.
```
$ cargo clippy --release -p frost-core --no-default-features -F internals

    Checking frost-core v2.0.0-rc.0 (/tmp/frost/frost-core)
warning: function `detect_cheater` is never used
   --> frost-core/src/lib.rs:637:4
    |
637 | fn detect_cheater<C: Ciphersuite>(
    |    ^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
```
