### PR TITLE
Removed unnecessary article to improve sentence clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Besides FROST itself, this repository also provides:
 - Distributed key generation as specified in the original paper [FROST20](https://eprint.iacr.org/2020/852.pdf);
 - Repairable Threshold Scheme (RTS) from ['A Survey and Refinement of Repairable Threshold Schemes'](https://eprint.iacr.org/2017/1155) which allows a participant to recover a lost share with the help of a threshold of other participants;
 - Rerandomized FROST (paper under review).
-- Refresh Share functionality using a Trusted Dealer. This can be used to refresh the shares of the participants or to remove a participant.
+- Refresh Share functionality using a Trusted Dealer. This can be used to refresh the shares of participants or remove a participant.
 
 ## Getting Started
 


### PR DESCRIPTION
Fixed:
Changed "refresh the shares of the participants or to remove a participant" to "refresh the shares of participants or remove a participant". Removed the extra article "the" to streamline the sentence.

Why it's useful:
This change improves sentence clarity and flow by removing unnecessary words, making the text more concise.