### PR TITLE
core: prevent creating a zero identifier with deserialization

### DIFF
--- a/frost-core/src/identifier.rs
+++ b/frost-core/src/identifier.rs
@@ -69,7 +69,7 @@ where
     /// Deserialize an Identifier from a serialized buffer.
     /// Returns an error if it attempts to deserialize zero.
     pub fn deserialize(bytes: &[u8]) -> Result<Self, Error<C>> {
-        Ok(Self(SerializableScalar::deserialize(bytes)?))
+        Self::new(SerializableScalar::deserialize(bytes)?.0)
     }
 }
 

--- a/frost-ristretto255/tests/integration_tests.rs
+++ b/frost-ristretto255/tests/integration_tests.rs
@@ -357,3 +357,12 @@ fn check_sign_with_incorrect_commitments() {
         _,
     >(rng);
 }
+
+// Test if deserializing the identifier 0 fails.
+// https://github.com/ZcashFoundation/frost/issues/793
+#[test]
+fn check_zero_identifier_deserialization() {
+    let arr: [u8; 32] = [0; 32];
+    let r = Identifier::deserialize(&arr);
+    assert_eq!(r, Err(Error::FieldError(FieldError::InvalidZeroScalar)));
+}

--- a/frost-ristretto255/tests/integration_tests.rs
+++ b/frost-ristretto255/tests/integration_tests.rs
@@ -357,12 +357,3 @@ fn check_sign_with_incorrect_commitments() {
         _,
     >(rng);
 }
-
-// Test if deserializing the identifier 0 fails.
-// https://github.com/ZcashFoundation/frost/issues/793
-#[test]
-fn check_zero_identifier_deserialization() {
-    let arr: [u8; 32] = [0; 32];
-    let r = Identifier::deserialize(&arr);
-    assert_eq!(r, Err(Error::FieldError(FieldError::InvalidZeroScalar)));
-}

--- a/frost-secp256k1/src/tests/deserialize.rs
+++ b/frost-secp256k1/src/tests/deserialize.rs
@@ -36,3 +36,12 @@ fn check_deserialize_identity() {
     let r = <Secp256K1Sha256 as Ciphersuite>::Group::deserialize(&encoded_identity);
     assert_eq!(r, Err(GroupError::MalformedElement));
 }
+
+// Test if deserializing the identifier 0 fails.
+// https://github.com/ZcashFoundation/frost/issues/793
+#[test]
+fn check_zero_identifier_deserialization() {
+    let arr: [u8; 32] = [0; 32];
+    let r = Identifier::deserialize(&arr);
+    assert_eq!(r, Err(Error::FieldError(FieldError::InvalidZeroScalar)));
+}


### PR DESCRIPTION
Closes #793 