### PR TITLE
fix(frost-secp256k1-tr): add missing `pub mod refresh` and missing test

### DIFF
--- a/frost-secp256k1-tr/src/lib.rs
+++ b/frost-secp256k1-tr/src/lib.rs
@@ -787,6 +787,7 @@ pub mod keys {
     }
 
     pub mod dkg;
+    pub mod refresh;
     pub mod repairable;
 }
 

--- a/frost-secp256k1-tr/tests/integration_tests.rs
+++ b/frost-secp256k1-tr/tests/integration_tests.rs
@@ -182,6 +182,13 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_identifier() {
 }
 
 #[test]
+fn check_refresh_shares_with_dkg() {
+    let rng = thread_rng();
+
+    frost_core::tests::refresh::check_refresh_shares_with_dkg::<Secp256K1Sha256TR, _>(rng);
+}
+
+#[test]
 fn check_sign_with_dealer() {
     let rng = thread_rng();
 


### PR DESCRIPTION
@conradoplg missed in #766
also fixes CI: `cargo run --bin gencode -- --check`

I'm sure how to fix warnings:
```
WARNING: documentation for aggregate_with_tweak is not available in base file. This can mean it's a specific type for the ciphersuite, or that there is a bug in gencode
WARNING: documentation for sign_with_tweak is not available in base file. This can mean it's a specific type for the ciphersuite, or that there is a bug in gencode
WARNING: documentation for Tweak is not available in base file. This can mean it's a specific type for the ciphersuite, or that there is a bug in gencode
WARNING: documentation for EvenY is not available in base file. This can mean it's a specific type for the ciphersuite, or that there is a bug in gencode
```
