### PR TITLE
ci: fail on doc warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,6 +176,8 @@ jobs:
   docs:
     name: Check Rust doc
     runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings
 
     steps:
       - uses: actions/checkout@v4.2.2


### PR DESCRIPTION
This turns doc warnings into errors, making sure we don't miss them.