### PR TITLE
Fix typos in `lib.rs` and `keys.rs`

### DIFF
--- a/frost-core/src/keys.rs
+++ b/frost-core/src/keys.rs
@@ -319,7 +319,7 @@ where
         Self(coefficients)
     }
 
-    /// Returns serialized coefficent commitments
+    /// Returns serialized coefficient commitments
     pub fn serialize(&self) -> Result<Vec<Vec<u8>>, Error<C>> {
         self.0
             .iter()

--- a/frost-core/src/lib.rs
+++ b/frost-core/src/lib.rs
@@ -419,7 +419,7 @@ where
     ) -> Result<Vec<(Identifier<C>, Vec<u8>)>, Error<C>> {
         let mut binding_factor_input_prefix = Vec::new();
 
-        // The length of a serialized verifying key of the same cipersuite does
+        // The length of a serialized verifying key of the same ciphersuite does
         // not change between runs of the protocol, so we don't need to hash to
         // get a fixed length.
         binding_factor_input_prefix.extend_from_slice(verifying_key.serialize()?.as_ref());


### PR DESCRIPTION


## 📝 Title
Fix typos in `lib.rs` and `keys.rs`

---

## 🔍 Description
This pull request fixes two typos in the following files:
1. **keys.rs**:
   - Corrected "coefficent" to "coefficient" in the comment.
2. **lib.rs**:
   - Corrected "cipersuite" to "ciphersuite" in the comment.

These changes improve the clarity and correctness of the code comments.

---

## 📂 Related Files
The changes were made in the following files:
- `frost-core/src/keys.rs`
- `frost-core/src/lib.rs`

---

## ✅ Checklist
- [x] Changes are purely textual and do not affect functionality.
- [x] Comments and documentation were reviewed and updated as needed.
- [x] All changes adhere to the repository's contributing guidelines.

---

## 📌 Related Issues
This PR does not address any specific issues but is part of general code maintenance and improvement.

---

## 📎 Additional Notes
- These changes are limited to fixing typos in comments. No logic or functional changes have been introduced.
- The corrections ensure better readability and professionalism in the code documentation.
