### PR TITLE
frost-core: fix visibility of coefficients()

### DIFF
--- a/frost-core/src/keys/dkg.rs
+++ b/frost-core/src/keys/dkg.rs
@@ -160,8 +160,8 @@ pub mod round1 {
         }
 
         /// Returns the secret coefficients.
-        #[cfg(feature = "internals")]
-        pub fn coefficients(&self) -> Vec<Scalar<C>> {
+        #[cfg_attr(feature = "internals", visibility::make(pub))]
+        pub(crate) fn coefficients(&self) -> Vec<Scalar<C>> {
             self.coefficients.iter().map(|s| s.0).collect()
         }
     }


### PR DESCRIPTION
The new SecretPackage serialization code is breaking when the `internals` feature is disabled