### PR TITLE
Update LICENSE.Apache-2.0

### DIFF
--- a/LICENSE.Apache-2.0
+++ b/LICENSE.Apache-2.0
@@ -1,4 +1,4 @@
-Copyright 2019-2021 Zcash Foundation
+Copyright 2019-2025 Zcash Foundation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updated the copyright year from 2021 to 2025 in the LICENSE file.