### PR TITLE
all: use OsRng instead of thread_rng()

### DIFF
--- a/frost-ed25519/README.md
+++ b/frost-ed25519/README.md
@@ -11,10 +11,9 @@ scenario in a single thread and it abstracts away any communication between peer
 ```rust
 # // ANCHOR: tkg_gen
 use frost_ed25519 as frost;
-use rand::thread_rng;
 use std::collections::BTreeMap;
 
-let mut rng = thread_rng();
+let mut rng = rand::rngs::OsRng;
 let max_signers = 5;
 let min_signers = 3;
 let (shares, pubkey_package) = frost::keys::generate_with_dealer(

--- a/frost-ed25519/benches/bench.rs
+++ b/frost-ed25519/benches/bench.rs
@@ -1,16 +1,15 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use rand::thread_rng;
 
 use frost_ed25519::*;
 
 fn bench_ed25519_batch_verify(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
 
     frost_core::benches::bench_batch_verify::<Ed25519Sha512, _>(c, "ed25519", &mut rng);
 }
 
 fn bench_ed25519_sign(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
 
     frost_core::benches::bench_sign::<Ed25519Sha512, _>(c, "ed25519", &mut rng);
 }

--- a/frost-ed25519/dkg.md
+++ b/frost-ed25519/dkg.md
@@ -26,12 +26,11 @@ they can proceed to sign messages with FROST.
 
 ```rust
 # // ANCHOR: dkg_import
-use rand::thread_rng;
 use std::collections::BTreeMap;
 
 use frost_ed25519 as frost;
 
-let mut rng = thread_rng();
+let mut rng = rand::rngs::OsRng;
 
 let max_signers = 5;
 let min_signers = 3;

--- a/frost-ed25519/src/keys/repairable.rs
+++ b/frost-ed25519/src/keys/repairable.rs
@@ -58,7 +58,7 @@ pub fn repair_share_step_3(
 mod tests {
 
     use lazy_static::lazy_static;
-    use rand::thread_rng;
+
     use serde_json::Value;
 
     use crate::Ed25519Sha512;
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_1() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
 
         frost_core::tests::repairable::check_repair_share_step_1::<Ed25519Sha512, _>(rng);
     }
@@ -83,7 +83,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_3() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
         frost_core::tests::repairable::check_repair_share_step_3::<Ed25519Sha512, _>(
             rng,
             &REPAIR_SHARE,
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_1_fails_with_invalid_min_signers() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
         frost_core::tests::repairable::check_repair_share_step_1_fails_with_invalid_min_signers::<
             Ed25519Sha512,
             _,

--- a/frost-ed25519/src/tests/batch.rs
+++ b/frost-ed25519/src/tests/batch.rs
@@ -1,24 +1,22 @@
-use rand::thread_rng;
-
 use crate::*;
 
 #[test]
 fn check_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::batch_verify::<Ed25519Sha512, _>(rng);
 }
 
 #[test]
 fn check_bad_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::bad_batch_verify::<Ed25519Sha512, _>(rng);
 }
 
 #[test]
 fn empty_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::empty_batch_verify::<Ed25519Sha512, _>(rng);
 }

--- a/frost-ed25519/src/tests/coefficient_commitment.rs
+++ b/frost-ed25519/src/tests/coefficient_commitment.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 use crate::*;
@@ -13,7 +12,7 @@ lazy_static! {
 
 #[test]
 fn check_serialization_of_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::coefficient_commitment::check_serialization_of_coefficient_commitment::<
         Ed25519Sha512,
         _,
@@ -22,7 +21,7 @@ fn check_serialization_of_coefficient_commitment() {
 
 #[test]
 fn check_create_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::coefficient_commitment::check_create_coefficient_commitment::<
         Ed25519Sha512,
         _,
@@ -37,7 +36,7 @@ fn check_create_coefficient_commitment_error() {
 
 #[test]
 fn check_get_value_of_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::coefficient_commitment::check_get_value_of_coefficient_commitment::<
         Ed25519Sha512,

--- a/frost-ed25519/src/tests/vss_commitment.rs
+++ b/frost-ed25519/src/tests/vss_commitment.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 use crate::*;
@@ -13,19 +12,19 @@ lazy_static! {
 
 #[test]
 fn check_serialize_vss_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_serialize_vss_commitment::<Ed25519Sha512, _>(rng);
 }
 
 #[test]
 fn check_deserialize_vss_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_deserialize_vss_commitment::<Ed25519Sha512, _>(rng);
 }
 
 #[test]
 fn check_deserialize_vss_commitment_error() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_deserialize_vss_commitment_error::<Ed25519Sha512, _>(
         rng, &ELEMENTS,
     );
@@ -33,6 +32,6 @@ fn check_deserialize_vss_commitment_error() {
 
 #[test]
 fn check_compute_public_key_package() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_compute_public_key_package::<Ed25519Sha512, _>(rng);
 }

--- a/frost-ed25519/tests/common_traits_tests.rs
+++ b/frost-ed25519/tests/common_traits_tests.rs
@@ -4,7 +4,6 @@ mod helpers;
 
 use frost_ed25519::SigningKey;
 use helpers::samples;
-use rand::thread_rng;
 
 #[allow(clippy::unnecessary_literal_unwrap)]
 fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: T) {
@@ -20,7 +19,7 @@ fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: 
 
 #[test]
 fn check_signing_key_common_traits() {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
     let signing_key = SigningKey::new(&mut rng);
     check_common_traits_for_type(signing_key);
 }

--- a/frost-ed25519/tests/integration_tests.rs
+++ b/frost-ed25519/tests/integration_tests.rs
@@ -1,6 +1,5 @@
 use frost_ed25519::*;
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 #[test]
@@ -10,14 +9,14 @@ fn check_zero_key_fails() {
 
 #[test]
 fn check_sign_with_dkg() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Ed25519Sha512, _>(rng);
 }
 
 #[test]
 fn check_dkg_part1_fails_with_invalid_signers_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 1;
     let max_signers = 3;
@@ -31,7 +30,7 @@ fn check_dkg_part1_fails_with_invalid_signers_min_signers() {
 
 #[test]
 fn check_dkg_part1_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -45,7 +44,7 @@ fn check_dkg_part1_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_dkg_part1_fails_with_invalid_signers_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 1;
@@ -59,21 +58,21 @@ fn check_dkg_part1_fails_with_invalid_signers_max_signers() {
 
 #[test]
 fn check_rts() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::repairable::check_rts::<Ed25519Sha512, _>(rng);
 }
 
 #[test]
 fn check_refresh_shares_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer::<Ed25519Sha512, _>(rng);
 }
 
 #[test]
 fn check_refresh_shares_with_dealer_serialisation() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer_serialisation::<Ed25519Sha512, _>(
         rng,
@@ -82,7 +81,7 @@ fn check_refresh_shares_with_dealer_serialisation() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_public_key_package() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer_fails_with_invalid_public_key_package::<
         Ed25519Sha512,
@@ -92,7 +91,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_public_key_package() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -111,7 +110,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_unequal_num_identifiers_and_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -130,7 +129,7 @@ fn check_refresh_shares_with_dealer_fails_with_unequal_num_identifiers_and_max_s
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -149,7 +148,7 @@ fn check_refresh_shares_with_dealer_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![Identifier::try_from(1).unwrap()];
     let min_signers = 3;
     let max_signers = 1;
@@ -163,7 +162,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_max_signers() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_identifier() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(8).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -182,21 +181,21 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_identifier() {
 
 #[test]
 fn check_refresh_shares_with_dkg() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dkg::<Ed25519Sha512, _>(rng);
 }
 
 #[test]
 fn check_sign_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Ed25519Sha512, _>(rng);
 }
 
 #[test]
 fn check_sign_with_dealer_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 1;
     let max_signers = 3;
@@ -210,7 +209,7 @@ fn check_sign_with_dealer_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_sign_with_dealer_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -224,7 +223,7 @@ fn check_sign_with_dealer_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_sign_with_dealer_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 1;
@@ -240,13 +239,13 @@ fn check_sign_with_dealer_fails_with_invalid_max_signers() {
 /// value is working.
 #[test]
 fn check_share_generation_ed25519_sha512() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_share_generation::<Ed25519Sha512, _>(rng);
 }
 
 #[test]
 fn check_share_generation_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 0;
     let max_signers = 3;
@@ -260,7 +259,7 @@ fn check_share_generation_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_share_generation_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -274,7 +273,7 @@ fn check_share_generation_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_share_generation_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 0;
@@ -338,7 +337,7 @@ fn check_identifier_generation() -> Result<(), Error> {
 
 #[test]
 fn check_sign_with_dealer_and_identifiers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer_and_identifiers::<
         Ed25519Sha512,
@@ -348,7 +347,7 @@ fn check_sign_with_dealer_and_identifiers() {
 
 #[test]
 fn check_sign_with_missing_identifier() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_sign_with_missing_identifier::<Ed25519Sha512, _>(
         rng,
     );
@@ -356,7 +355,7 @@ fn check_sign_with_missing_identifier() {
 
 #[test]
 fn check_sign_with_incorrect_commitments() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_sign_with_incorrect_commitments::<Ed25519Sha512, _>(
         rng,
     );

--- a/frost-ed25519/tests/interoperability_tests.rs
+++ b/frost-ed25519/tests/interoperability_tests.rs
@@ -1,21 +1,18 @@
 use crate::Ed25519Sha512;
 use frost_ed25519::*;
-use rand::thread_rng;
 
 mod helpers;
 
 #[test]
 fn check_interoperability_in_sign_with_dkg() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     // Test with multiple keys/signatures to better exercise the key generation
     // and the interoperability check. A smaller number of iterations is used
     // because DKG takes longer and otherwise the test would be too slow.
     for _ in 0..32 {
         let (msg, group_signature, group_pubkey) =
-            frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Ed25519Sha512, _>(
-                rng.clone(),
-            );
+            frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Ed25519Sha512, _>(rng);
 
         helpers::verify_signature(&msg, group_signature, group_pubkey);
     }
@@ -23,15 +20,13 @@ fn check_interoperability_in_sign_with_dkg() {
 
 #[test]
 fn check_interoperability_in_sign_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     // Test with multiple keys/signatures to better exercise the key generation
     // and the interoperability check.
     for _ in 0..256 {
         let (msg, group_signature, group_pubkey) =
-            frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Ed25519Sha512, _>(
-                rng.clone(),
-            );
+            frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Ed25519Sha512, _>(rng);
 
         // Check that the threshold signature can be verified by the `ed25519_dalek` crate
         // public key (interoperability test)

--- a/frost-ed25519/tests/rerandomized_tests.rs
+++ b/frost-ed25519/tests/rerandomized_tests.rs
@@ -1,9 +1,8 @@
 use frost_ed25519::Ed25519Sha512;
-use rand::thread_rng;
 
 #[test]
 fn check_randomized_sign_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let (_msg, _group_signature, _group_pubkey) =
         frost_rerandomized::tests::check_randomized_sign_with_dealer::<Ed25519Sha512, _>(rng);

--- a/frost-ed448/README.md
+++ b/frost-ed448/README.md
@@ -11,10 +11,9 @@ scenario in a single thread and it abstracts away any communication between peer
 ```rust
 # // ANCHOR: tkg_gen
 use frost_ed448 as frost;
-use rand::thread_rng;
 use std::collections::BTreeMap;
 
-let mut rng = thread_rng();
+let mut rng = rand::rngs::OsRng;
 let max_signers = 5;
 let min_signers = 3;
 let (shares, pubkey_package) = frost::keys::generate_with_dealer(

--- a/frost-ed448/benches/bench.rs
+++ b/frost-ed448/benches/bench.rs
@@ -1,18 +1,17 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use rand::thread_rng;
 
 use frost_ed448::*;
 
 // bench_ed448_batch_verify not included until batch verification is fixed for Ed448
 #[allow(unused)]
 fn bench_ed448_batch_verify(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
 
     frost_core::benches::bench_batch_verify::<Ed448Shake256, _>(c, "ed448", &mut rng);
 }
 
 fn bench_ed448_sign(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
 
     frost_core::benches::bench_sign::<Ed448Shake256, _>(c, "ed448", &mut rng);
 }

--- a/frost-ed448/dkg.md
+++ b/frost-ed448/dkg.md
@@ -26,12 +26,11 @@ they can proceed to sign messages with FROST.
 
 ```rust
 # // ANCHOR: dkg_import
-use rand::thread_rng;
 use std::collections::BTreeMap;
 
 use frost_ed448 as frost;
 
-let mut rng = thread_rng();
+let mut rng = rand::rngs::OsRng;
 
 let max_signers = 5;
 let min_signers = 3;

--- a/frost-ed448/src/keys/repairable.rs
+++ b/frost-ed448/src/keys/repairable.rs
@@ -58,7 +58,7 @@ pub fn repair_share_step_3(
 mod tests {
 
     use lazy_static::lazy_static;
-    use rand::thread_rng;
+
     use serde_json::Value;
 
     use crate::Ed448Shake256;
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_1() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
 
         frost_core::tests::repairable::check_repair_share_step_1::<Ed448Shake256, _>(rng);
     }
@@ -83,7 +83,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_3() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
         frost_core::tests::repairable::check_repair_share_step_3::<Ed448Shake256, _>(
             rng,
             &REPAIR_SHARE,
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_1_fails_with_invalid_min_signers() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
         frost_core::tests::repairable::check_repair_share_step_1_fails_with_invalid_min_signers::<
             Ed448Shake256,
             _,

--- a/frost-ed448/src/tests/batch.rs
+++ b/frost-ed448/src/tests/batch.rs
@@ -1,24 +1,22 @@
-use rand::thread_rng;
-
 use crate::*;
 
 #[test]
 fn check_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::batch_verify::<Ed448Shake256, _>(rng);
 }
 
 #[test]
 fn check_bad_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::bad_batch_verify::<Ed448Shake256, _>(rng);
 }
 
 #[test]
 fn empty_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::empty_batch_verify::<Ed448Shake256, _>(rng);
 }

--- a/frost-ed448/src/tests/coefficient_commitment.rs
+++ b/frost-ed448/src/tests/coefficient_commitment.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 use crate::*;
@@ -13,7 +12,7 @@ lazy_static! {
 
 #[test]
 fn check_serialization_of_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::coefficient_commitment::check_serialization_of_coefficient_commitment::<
         Ed448Shake256,
         _,
@@ -22,7 +21,7 @@ fn check_serialization_of_coefficient_commitment() {
 
 #[test]
 fn check_create_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::coefficient_commitment::check_create_coefficient_commitment::<
         Ed448Shake256,
         _,
@@ -37,7 +36,7 @@ fn check_create_coefficient_commitment_error() {
 
 #[test]
 fn check_get_value_of_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::coefficient_commitment::check_get_value_of_coefficient_commitment::<
         Ed448Shake256,

--- a/frost-ed448/src/tests/vss_commitment.rs
+++ b/frost-ed448/src/tests/vss_commitment.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 use crate::*;
@@ -13,19 +12,19 @@ lazy_static! {
 
 #[test]
 fn check_serialize_vss_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_serialize_vss_commitment::<Ed448Shake256, _>(rng);
 }
 
 #[test]
 fn check_deserialize_vss_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_deserialize_vss_commitment::<Ed448Shake256, _>(rng);
 }
 
 #[test]
 fn check_deserialize_vss_commitment_error() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_deserialize_vss_commitment_error::<Ed448Shake256, _>(
         rng, &ELEMENTS,
     );
@@ -33,6 +32,6 @@ fn check_deserialize_vss_commitment_error() {
 
 #[test]
 fn check_compute_public_key_package() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_compute_public_key_package::<Ed448Shake256, _>(rng);
 }

--- a/frost-ed448/tests/common_traits_tests.rs
+++ b/frost-ed448/tests/common_traits_tests.rs
@@ -4,7 +4,6 @@ mod helpers;
 
 use frost_ed448::SigningKey;
 use helpers::samples;
-use rand::thread_rng;
 
 #[allow(clippy::unnecessary_literal_unwrap)]
 fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: T) {
@@ -20,7 +19,7 @@ fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: 
 
 #[test]
 fn check_signing_key_common_traits() {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
     let signing_key = SigningKey::new(&mut rng);
     check_common_traits_for_type(signing_key);
 }

--- a/frost-ed448/tests/integration_tests.rs
+++ b/frost-ed448/tests/integration_tests.rs
@@ -1,6 +1,5 @@
 use frost_ed448::*;
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 #[test]
@@ -10,14 +9,14 @@ fn check_zero_key_fails() {
 
 #[test]
 fn check_sign_with_dkg() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Ed448Shake256, _>(rng);
 }
 
 #[test]
 fn check_dkg_part1_fails_with_invalid_signers_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 1;
     let max_signers = 3;
@@ -31,7 +30,7 @@ fn check_dkg_part1_fails_with_invalid_signers_min_signers() {
 
 #[test]
 fn check_dkg_part1_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -45,7 +44,7 @@ fn check_dkg_part1_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_dkg_part1_fails_with_invalid_signers_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 1;
@@ -59,21 +58,21 @@ fn check_dkg_part1_fails_with_invalid_signers_max_signers() {
 
 #[test]
 fn check_rts() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::repairable::check_rts::<Ed448Shake256, _>(rng);
 }
 
 #[test]
 fn check_refresh_shares_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer::<Ed448Shake256, _>(rng);
 }
 
 #[test]
 fn check_refresh_shares_with_dealer_serialisation() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer_serialisation::<Ed448Shake256, _>(
         rng,
@@ -82,7 +81,7 @@ fn check_refresh_shares_with_dealer_serialisation() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_public_key_package() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer_fails_with_invalid_public_key_package::<
         Ed448Shake256,
@@ -92,7 +91,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_public_key_package() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -111,7 +110,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_unequal_num_identifiers_and_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -130,7 +129,7 @@ fn check_refresh_shares_with_dealer_fails_with_unequal_num_identifiers_and_max_s
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -149,7 +148,7 @@ fn check_refresh_shares_with_dealer_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![Identifier::try_from(1).unwrap()];
     let min_signers = 3;
     let max_signers = 1;
@@ -163,7 +162,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_max_signers() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_identifier() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(8).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -182,21 +181,21 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_identifier() {
 
 #[test]
 fn check_refresh_shares_with_dkg() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dkg::<Ed448Shake256, _>(rng);
 }
 
 #[test]
 fn check_sign_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Ed448Shake256, _>(rng);
 }
 
 #[test]
 fn check_sign_with_dealer_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 1;
     let max_signers = 3;
@@ -210,7 +209,7 @@ fn check_sign_with_dealer_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_sign_with_dealer_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -224,7 +223,7 @@ fn check_sign_with_dealer_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_sign_with_dealer_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 1;
@@ -240,13 +239,13 @@ fn check_sign_with_dealer_fails_with_invalid_max_signers() {
 /// value is working.
 #[test]
 fn check_share_generation_ed448_shake256() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_share_generation::<Ed448Shake256, _>(rng);
 }
 
 #[test]
 fn check_share_generation_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 0;
     let max_signers = 3;
@@ -260,7 +259,7 @@ fn check_share_generation_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_share_generation_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -274,7 +273,7 @@ fn check_share_generation_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_share_generation_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 0;
@@ -338,7 +337,7 @@ fn check_identifier_generation() -> Result<(), Error> {
 
 #[test]
 fn check_sign_with_dealer_and_identifiers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer_and_identifiers::<
         Ed448Shake256,
@@ -348,7 +347,7 @@ fn check_sign_with_dealer_and_identifiers() {
 
 #[test]
 fn check_sign_with_missing_identifier() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_sign_with_missing_identifier::<Ed448Shake256, _>(
         rng,
     );
@@ -356,7 +355,7 @@ fn check_sign_with_missing_identifier() {
 
 #[test]
 fn check_sign_with_incorrect_commitments() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_sign_with_incorrect_commitments::<Ed448Shake256, _>(
         rng,
     );

--- a/frost-ed448/tests/rerandomized_tests.rs
+++ b/frost-ed448/tests/rerandomized_tests.rs
@@ -1,9 +1,8 @@
 use frost_ed448::Ed448Shake256;
-use rand::thread_rng;
 
 #[test]
 fn check_randomized_sign_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let (_msg, _group_signature, _group_pubkey) =
         frost_rerandomized::tests::check_randomized_sign_with_dealer::<Ed448Shake256, _>(rng);

--- a/frost-p256/README.md
+++ b/frost-p256/README.md
@@ -11,10 +11,9 @@ scenario in a single thread and it abstracts away any communication between peer
 ```rust
 # // ANCHOR: tkg_gen
 use frost_p256 as frost;
-use rand::thread_rng;
 use std::collections::BTreeMap;
 
-let mut rng = thread_rng();
+let mut rng = rand::rngs::OsRng;
 let max_signers = 5;
 let min_signers = 3;
 let (shares, pubkey_package) = frost::keys::generate_with_dealer(

--- a/frost-p256/benches/bench.rs
+++ b/frost-p256/benches/bench.rs
@@ -1,16 +1,15 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use rand::thread_rng;
 
 use frost_p256::*;
 
 fn bench_p256_batch_verify(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
 
     frost_core::benches::bench_batch_verify::<P256Sha256, _>(c, "p256", &mut rng);
 }
 
 fn bench_p256_sign(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
 
     frost_core::benches::bench_sign::<P256Sha256, _>(c, "p256", &mut rng);
 }

--- a/frost-p256/dkg.md
+++ b/frost-p256/dkg.md
@@ -26,12 +26,11 @@ they can proceed to sign messages with FROST.
 
 ```rust
 # // ANCHOR: dkg_import
-use rand::thread_rng;
 use std::collections::BTreeMap;
 
 use frost_p256 as frost;
 
-let mut rng = thread_rng();
+let mut rng = rand::rngs::OsRng;
 
 let max_signers = 5;
 let min_signers = 3;

--- a/frost-p256/src/keys/repairable.rs
+++ b/frost-p256/src/keys/repairable.rs
@@ -58,7 +58,7 @@ pub fn repair_share_step_3(
 mod tests {
 
     use lazy_static::lazy_static;
-    use rand::thread_rng;
+
     use serde_json::Value;
 
     use crate::P256Sha256;
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_1() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
 
         frost_core::tests::repairable::check_repair_share_step_1::<P256Sha256, _>(rng);
     }
@@ -83,7 +83,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_3() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
         frost_core::tests::repairable::check_repair_share_step_3::<P256Sha256, _>(
             rng,
             &REPAIR_SHARE,
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_1_fails_with_invalid_min_signers() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
         frost_core::tests::repairable::check_repair_share_step_1_fails_with_invalid_min_signers::<
             P256Sha256,
             _,

--- a/frost-p256/src/tests/batch.rs
+++ b/frost-p256/src/tests/batch.rs
@@ -1,24 +1,22 @@
-use rand::thread_rng;
-
 use crate::*;
 
 #[test]
 fn check_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::batch_verify::<P256Sha256, _>(rng);
 }
 
 #[test]
 fn check_bad_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::bad_batch_verify::<P256Sha256, _>(rng);
 }
 
 #[test]
 fn empty_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::empty_batch_verify::<P256Sha256, _>(rng);
 }

--- a/frost-p256/src/tests/coefficient_commitment.rs
+++ b/frost-p256/src/tests/coefficient_commitment.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 use crate::*;
@@ -13,7 +12,7 @@ lazy_static! {
 
 #[test]
 fn check_serialization_of_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::coefficient_commitment::check_serialization_of_coefficient_commitment::<
         P256Sha256,
         _,
@@ -22,7 +21,7 @@ fn check_serialization_of_coefficient_commitment() {
 
 #[test]
 fn check_create_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::coefficient_commitment::check_create_coefficient_commitment::<P256Sha256, _>(
         rng,
     );
@@ -36,7 +35,7 @@ fn check_create_coefficient_commitment_error() {
 
 #[test]
 fn check_get_value_of_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::coefficient_commitment::check_get_value_of_coefficient_commitment::<
         P256Sha256,

--- a/frost-p256/src/tests/vss_commitment.rs
+++ b/frost-p256/src/tests/vss_commitment.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 use crate::*;
@@ -13,19 +12,19 @@ lazy_static! {
 
 #[test]
 fn check_serialize_vss_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_serialize_vss_commitment::<P256Sha256, _>(rng);
 }
 
 #[test]
 fn check_deserialize_vss_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_deserialize_vss_commitment::<P256Sha256, _>(rng);
 }
 
 #[test]
 fn check_deserialize_vss_commitment_error() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_deserialize_vss_commitment_error::<P256Sha256, _>(
         rng, &ELEMENTS,
     );
@@ -33,6 +32,6 @@ fn check_deserialize_vss_commitment_error() {
 
 #[test]
 fn check_compute_public_key_package() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_compute_public_key_package::<P256Sha256, _>(rng);
 }

--- a/frost-p256/tests/common_traits_tests.rs
+++ b/frost-p256/tests/common_traits_tests.rs
@@ -4,7 +4,6 @@ mod helpers;
 
 use frost_p256::SigningKey;
 use helpers::samples;
-use rand::thread_rng;
 
 #[allow(clippy::unnecessary_literal_unwrap)]
 fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: T) {
@@ -20,7 +19,7 @@ fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: 
 
 #[test]
 fn check_signing_key_common_traits() {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
     let signing_key = SigningKey::new(&mut rng);
     check_common_traits_for_type(signing_key);
 }

--- a/frost-p256/tests/integration_tests.rs
+++ b/frost-p256/tests/integration_tests.rs
@@ -1,6 +1,5 @@
 use frost_p256::*;
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 #[test]
@@ -10,14 +9,14 @@ fn check_zero_key_fails() {
 
 #[test]
 fn check_sign_with_dkg() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<P256Sha256, _>(rng);
 }
 
 #[test]
 fn check_dkg_part1_fails_with_invalid_signers_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 1;
     let max_signers = 3;
@@ -31,7 +30,7 @@ fn check_dkg_part1_fails_with_invalid_signers_min_signers() {
 
 #[test]
 fn check_dkg_part1_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -45,7 +44,7 @@ fn check_dkg_part1_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_dkg_part1_fails_with_invalid_signers_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 1;
@@ -59,21 +58,21 @@ fn check_dkg_part1_fails_with_invalid_signers_max_signers() {
 
 #[test]
 fn check_rts() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::repairable::check_rts::<P256Sha256, _>(rng);
 }
 
 #[test]
 fn check_refresh_shares_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer::<P256Sha256, _>(rng);
 }
 
 #[test]
 fn check_refresh_shares_with_dealer_serialisation() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer_serialisation::<P256Sha256, _>(
         rng,
@@ -82,7 +81,7 @@ fn check_refresh_shares_with_dealer_serialisation() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_public_key_package() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer_fails_with_invalid_public_key_package::<
         P256Sha256,
@@ -92,7 +91,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_public_key_package() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -111,7 +110,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_unequal_num_identifiers_and_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -130,7 +129,7 @@ fn check_refresh_shares_with_dealer_fails_with_unequal_num_identifiers_and_max_s
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -149,7 +148,7 @@ fn check_refresh_shares_with_dealer_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![Identifier::try_from(1).unwrap()];
     let min_signers = 3;
     let max_signers = 1;
@@ -163,7 +162,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_max_signers() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_identifier() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(8).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -182,21 +181,21 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_identifier() {
 
 #[test]
 fn check_refresh_shares_with_dkg() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dkg::<P256Sha256, _>(rng);
 }
 
 #[test]
 fn check_sign_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<P256Sha256, _>(rng);
 }
 
 #[test]
 fn check_sign_with_dealer_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 1;
     let max_signers = 3;
@@ -210,7 +209,7 @@ fn check_sign_with_dealer_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_sign_with_dealer_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -224,7 +223,7 @@ fn check_sign_with_dealer_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_sign_with_dealer_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 1;
@@ -240,13 +239,13 @@ fn check_sign_with_dealer_fails_with_invalid_max_signers() {
 /// value is working.
 #[test]
 fn check_share_generation_p256_sha256() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_share_generation::<P256Sha256, _>(rng);
 }
 
 #[test]
 fn check_share_generation_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 0;
     let max_signers = 3;
@@ -260,7 +259,7 @@ fn check_share_generation_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_share_generation_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -274,7 +273,7 @@ fn check_share_generation_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_share_generation_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 0;
@@ -336,7 +335,7 @@ fn check_identifier_generation() -> Result<(), Error> {
 
 #[test]
 fn check_sign_with_dealer_and_identifiers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer_and_identifiers::<P256Sha256, _>(
         rng,
@@ -345,7 +344,7 @@ fn check_sign_with_dealer_and_identifiers() {
 
 #[test]
 fn check_sign_with_missing_identifier() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_sign_with_missing_identifier::<P256Sha256, _>(
         rng,
     );
@@ -353,7 +352,7 @@ fn check_sign_with_missing_identifier() {
 
 #[test]
 fn check_sign_with_incorrect_commitments() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_sign_with_incorrect_commitments::<P256Sha256, _>(
         rng,
     );

--- a/frost-p256/tests/rerandomized_tests.rs
+++ b/frost-p256/tests/rerandomized_tests.rs
@@ -1,9 +1,8 @@
 use frost_p256::P256Sha256;
-use rand::thread_rng;
 
 #[test]
 fn check_randomized_sign_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let (_msg, _group_signature, _group_pubkey) =
         frost_rerandomized::tests::check_randomized_sign_with_dealer::<P256Sha256, _>(rng);

--- a/frost-ristretto255/README.md
+++ b/frost-ristretto255/README.md
@@ -11,10 +11,9 @@ scenario in a single thread and it abstracts away any communication between peer
 ```rust
 # // ANCHOR: tkg_gen
 use frost_ristretto255 as frost;
-use rand::thread_rng;
 use std::collections::BTreeMap;
 
-let mut rng = thread_rng();
+let mut rng = rand::rngs::OsRng;
 let max_signers = 5;
 let min_signers = 3;
 let (shares, pubkey_package) = frost::keys::generate_with_dealer(

--- a/frost-ristretto255/benches/bench.rs
+++ b/frost-ristretto255/benches/bench.rs
@@ -1,16 +1,15 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use rand::thread_rng;
 
 use frost_ristretto255::*;
 
 fn bench_ristretto255_batch_verify(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
 
     frost_core::benches::bench_batch_verify::<Ristretto255Sha512, _>(c, "ristretto255", &mut rng);
 }
 
 fn bench_ristretto255_sign(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
 
     frost_core::benches::bench_sign::<Ristretto255Sha512, _>(c, "ristretto255", &mut rng);
 }

--- a/frost-ristretto255/dkg.md
+++ b/frost-ristretto255/dkg.md
@@ -26,12 +26,11 @@ they can proceed to sign messages with FROST.
 
 ```rust
 # // ANCHOR: dkg_import
-use rand::thread_rng;
 use std::collections::BTreeMap;
 
 use frost_ristretto255 as frost;
 
-let mut rng = thread_rng();
+let mut rng = rand::rngs::OsRng;
 
 let max_signers = 5;
 let min_signers = 3;

--- a/frost-ristretto255/src/keys/repairable.rs
+++ b/frost-ristretto255/src/keys/repairable.rs
@@ -58,7 +58,7 @@ pub fn repair_share_step_3(
 mod tests {
 
     use lazy_static::lazy_static;
-    use rand::thread_rng;
+
     use serde_json::Value;
 
     use crate::Ristretto255Sha512;
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_1() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
 
         frost_core::tests::repairable::check_repair_share_step_1::<Ristretto255Sha512, _>(rng);
     }
@@ -85,7 +85,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_3() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
         frost_core::tests::repairable::check_repair_share_step_3::<Ristretto255Sha512, _>(
             rng,
             &REPAIR_SHARE,
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_1_fails_with_invalid_min_signers() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
         frost_core::tests::repairable::check_repair_share_step_1_fails_with_invalid_min_signers::<
             Ristretto255Sha512,
             _,

--- a/frost-ristretto255/src/tests/batch.rs
+++ b/frost-ristretto255/src/tests/batch.rs
@@ -1,24 +1,22 @@
-use rand::thread_rng;
-
 use crate::*;
 
 #[test]
 fn check_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::batch_verify::<Ristretto255Sha512, _>(rng);
 }
 
 #[test]
 fn check_bad_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::bad_batch_verify::<Ristretto255Sha512, _>(rng);
 }
 
 #[test]
 fn empty_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::empty_batch_verify::<Ristretto255Sha512, _>(rng);
 }

--- a/frost-ristretto255/src/tests/coefficient_commitment.rs
+++ b/frost-ristretto255/src/tests/coefficient_commitment.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 use crate::*;
@@ -13,7 +12,7 @@ lazy_static! {
 
 #[test]
 fn check_serialization_of_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::coefficient_commitment::check_serialization_of_coefficient_commitment::<
         Ristretto255Sha512,
         _,
@@ -22,7 +21,7 @@ fn check_serialization_of_coefficient_commitment() {
 
 #[test]
 fn check_create_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::coefficient_commitment::check_create_coefficient_commitment::<
         Ristretto255Sha512,
         _,
@@ -37,7 +36,7 @@ fn check_create_coefficient_commitment_error() {
 
 #[test]
 fn check_get_value_of_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::coefficient_commitment::check_get_value_of_coefficient_commitment::<
         Ristretto255Sha512,

--- a/frost-ristretto255/src/tests/vss_commitment.rs
+++ b/frost-ristretto255/src/tests/vss_commitment.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 use crate::*;
@@ -13,13 +12,13 @@ lazy_static! {
 
 #[test]
 fn check_serialize_vss_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_serialize_vss_commitment::<Ristretto255Sha512, _>(rng);
 }
 
 #[test]
 fn check_deserialize_vss_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_deserialize_vss_commitment::<Ristretto255Sha512, _>(
         rng,
     );
@@ -27,7 +26,7 @@ fn check_deserialize_vss_commitment() {
 
 #[test]
 fn check_deserialize_vss_commitment_error() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_deserialize_vss_commitment_error::<
         Ristretto255Sha512,
         _,
@@ -36,7 +35,7 @@ fn check_deserialize_vss_commitment_error() {
 
 #[test]
 fn check_compute_public_key_package() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_compute_public_key_package::<Ristretto255Sha512, _>(
         rng,
     );

--- a/frost-ristretto255/tests/common_traits_tests.rs
+++ b/frost-ristretto255/tests/common_traits_tests.rs
@@ -4,7 +4,6 @@ mod helpers;
 
 use frost_ristretto255::SigningKey;
 use helpers::samples;
-use rand::thread_rng;
 
 #[allow(clippy::unnecessary_literal_unwrap)]
 fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: T) {
@@ -20,7 +19,7 @@ fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: 
 
 #[test]
 fn check_signing_key_common_traits() {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
     let signing_key = SigningKey::new(&mut rng);
     check_common_traits_for_type(signing_key);
 }

--- a/frost-ristretto255/tests/integration_tests.rs
+++ b/frost-ristretto255/tests/integration_tests.rs
@@ -1,6 +1,5 @@
 use frost_ristretto255::*;
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 #[test]
@@ -10,14 +9,14 @@ fn check_zero_key_fails() {
 
 #[test]
 fn check_sign_with_dkg() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Ristretto255Sha512, _>(rng);
 }
 
 #[test]
 fn check_dkg_part1_fails_with_invalid_signers_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 1;
     let max_signers = 3;
@@ -31,7 +30,7 @@ fn check_dkg_part1_fails_with_invalid_signers_min_signers() {
 
 #[test]
 fn check_dkg_part1_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -45,7 +44,7 @@ fn check_dkg_part1_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_dkg_part1_fails_with_invalid_signers_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 1;
@@ -59,21 +58,21 @@ fn check_dkg_part1_fails_with_invalid_signers_max_signers() {
 
 #[test]
 fn check_rts() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::repairable::check_rts::<Ristretto255Sha512, _>(rng);
 }
 
 #[test]
 fn check_refresh_shares_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer::<Ristretto255Sha512, _>(rng);
 }
 
 #[test]
 fn check_refresh_shares_with_dealer_serialisation() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer_serialisation::<
         Ristretto255Sha512,
@@ -83,7 +82,7 @@ fn check_refresh_shares_with_dealer_serialisation() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_public_key_package() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer_fails_with_invalid_public_key_package::<
         Ristretto255Sha512,
@@ -93,7 +92,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_public_key_package() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -112,7 +111,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_unequal_num_identifiers_and_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -131,7 +130,7 @@ fn check_refresh_shares_with_dealer_fails_with_unequal_num_identifiers_and_max_s
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -150,7 +149,7 @@ fn check_refresh_shares_with_dealer_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![Identifier::try_from(1).unwrap()];
     let min_signers = 3;
     let max_signers = 1;
@@ -164,7 +163,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_max_signers() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_identifier() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(8).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -183,21 +182,21 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_identifier() {
 
 #[test]
 fn check_refresh_shares_with_dkg() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dkg::<Ristretto255Sha512, _>(rng);
 }
 
 #[test]
 fn check_sign_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Ristretto255Sha512, _>(rng);
 }
 
 #[test]
 fn check_sign_with_dealer_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 1;
     let max_signers = 3;
@@ -211,7 +210,7 @@ fn check_sign_with_dealer_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_sign_with_dealer_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -225,7 +224,7 @@ fn check_sign_with_dealer_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_sign_with_dealer_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 1;
@@ -241,13 +240,13 @@ fn check_sign_with_dealer_fails_with_invalid_max_signers() {
 /// value is working.
 #[test]
 fn check_share_generation_ristretto255_sha512() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_share_generation::<Ristretto255Sha512, _>(rng);
 }
 
 #[test]
 fn check_share_generation_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 0;
     let max_signers = 3;
@@ -261,7 +260,7 @@ fn check_share_generation_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_share_generation_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -275,7 +274,7 @@ fn check_share_generation_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_share_generation_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 0;
@@ -339,7 +338,7 @@ fn check_identifier_generation() -> Result<(), Error> {
 
 #[test]
 fn check_sign_with_dealer_and_identifiers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer_and_identifiers::<
         Ristretto255Sha512,
@@ -349,7 +348,7 @@ fn check_sign_with_dealer_and_identifiers() {
 
 #[test]
 fn check_sign_with_missing_identifier() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_sign_with_missing_identifier::<
         Ristretto255Sha512,
         _,
@@ -358,7 +357,7 @@ fn check_sign_with_missing_identifier() {
 
 #[test]
 fn check_sign_with_incorrect_commitments() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_sign_with_incorrect_commitments::<
         Ristretto255Sha512,
         _,

--- a/frost-ristretto255/tests/rerandomized_tests.rs
+++ b/frost-ristretto255/tests/rerandomized_tests.rs
@@ -1,9 +1,8 @@
 use frost_ristretto255::Ristretto255Sha512;
-use rand::thread_rng;
 
 #[test]
 fn check_randomized_sign_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let (_msg, _group_signature, _group_pubkey) =
         frost_rerandomized::tests::check_randomized_sign_with_dealer::<Ristretto255Sha512, _>(rng);

--- a/frost-secp256k1-tr/README.md
+++ b/frost-secp256k1-tr/README.md
@@ -11,10 +11,9 @@ scenario in a single thread and it abstracts away any communication between peer
 ```rust
 # // ANCHOR: tkg_gen
 use frost_secp256k1_tr as frost;
-use rand::thread_rng;
 use std::collections::BTreeMap;
 
-let mut rng = thread_rng();
+let mut rng = rand::rngs::OsRng;
 let max_signers = 5;
 let min_signers = 3;
 let (shares, pubkey_package) = frost::keys::generate_with_dealer(

--- a/frost-secp256k1-tr/benches/bench.rs
+++ b/frost-secp256k1-tr/benches/bench.rs
@@ -1,16 +1,15 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use rand::thread_rng;
 
 use frost_secp256k1_tr::*;
 
 fn bench_secp256k1_batch_verify(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
 
     frost_core::benches::bench_batch_verify::<Secp256K1Sha256TR, _>(c, "secp256k1", &mut rng);
 }
 
 fn bench_secp256k1_sign(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
 
     frost_core::benches::bench_sign::<Secp256K1Sha256TR, _>(c, "secp256k1", &mut rng);
 }

--- a/frost-secp256k1-tr/dkg.md
+++ b/frost-secp256k1-tr/dkg.md
@@ -26,12 +26,11 @@ they can proceed to sign messages with FROST.
 
 ```rust
 # // ANCHOR: dkg_import
-use rand::thread_rng;
 use std::collections::BTreeMap;
 
 use frost_secp256k1_tr as frost;
 
-let mut rng = thread_rng();
+let mut rng = rand::rngs::OsRng;
 
 let max_signers = 5;
 let min_signers = 3;

--- a/frost-secp256k1-tr/src/keys/repairable.rs
+++ b/frost-secp256k1-tr/src/keys/repairable.rs
@@ -58,7 +58,7 @@ pub fn repair_share_step_3(
 mod tests {
 
     use lazy_static::lazy_static;
-    use rand::thread_rng;
+
     use serde_json::Value;
 
     use crate::Secp256K1Sha256TR;
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_1() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
 
         frost_core::tests::repairable::check_repair_share_step_1::<Secp256K1Sha256TR, _>(rng);
     }
@@ -85,7 +85,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_3() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
         frost_core::tests::repairable::check_repair_share_step_3::<Secp256K1Sha256TR, _>(
             rng,
             &REPAIR_SHARE,
@@ -94,7 +94,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_1_fails_with_invalid_min_signers() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
         frost_core::tests::repairable::check_repair_share_step_1_fails_with_invalid_min_signers::<
             Secp256K1Sha256TR,
             _,

--- a/frost-secp256k1-tr/src/tests/batch.rs
+++ b/frost-secp256k1-tr/src/tests/batch.rs
@@ -1,24 +1,22 @@
-use rand::thread_rng;
-
 use crate::*;
 
 #[test]
 fn check_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::batch_verify::<Secp256K1Sha256TR, _>(rng);
 }
 
 #[test]
 fn check_bad_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::bad_batch_verify::<Secp256K1Sha256TR, _>(rng);
 }
 
 #[test]
 fn empty_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::empty_batch_verify::<Secp256K1Sha256TR, _>(rng);
 }

--- a/frost-secp256k1-tr/src/tests/coefficient_commitment.rs
+++ b/frost-secp256k1-tr/src/tests/coefficient_commitment.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 use crate::*;
@@ -13,7 +12,7 @@ lazy_static! {
 
 #[test]
 fn check_serialization_of_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::coefficient_commitment::check_serialization_of_coefficient_commitment::<
         Secp256K1Sha256TR,
         _,
@@ -22,7 +21,7 @@ fn check_serialization_of_coefficient_commitment() {
 
 #[test]
 fn check_create_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::coefficient_commitment::check_create_coefficient_commitment::<
         Secp256K1Sha256TR,
         _,
@@ -37,7 +36,7 @@ fn check_create_coefficient_commitment_error() {
 
 #[test]
 fn check_get_value_of_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::coefficient_commitment::check_get_value_of_coefficient_commitment::<
         Secp256K1Sha256TR,

--- a/frost-secp256k1-tr/src/tests/vss_commitment.rs
+++ b/frost-secp256k1-tr/src/tests/vss_commitment.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 use crate::*;
@@ -13,13 +12,13 @@ lazy_static! {
 
 #[test]
 fn check_serialize_vss_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_serialize_vss_commitment::<Secp256K1Sha256TR, _>(rng);
 }
 
 #[test]
 fn check_deserialize_vss_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_deserialize_vss_commitment::<Secp256K1Sha256TR, _>(
         rng,
     );
@@ -27,7 +26,7 @@ fn check_deserialize_vss_commitment() {
 
 #[test]
 fn check_deserialize_vss_commitment_error() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_deserialize_vss_commitment_error::<Secp256K1Sha256TR, _>(
         rng, &ELEMENTS,
     );
@@ -35,7 +34,7 @@ fn check_deserialize_vss_commitment_error() {
 
 #[test]
 fn check_compute_public_key_package() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_compute_public_key_package::<Secp256K1Sha256TR, _>(
         rng,
     );

--- a/frost-secp256k1-tr/tests/common_traits_tests.rs
+++ b/frost-secp256k1-tr/tests/common_traits_tests.rs
@@ -4,7 +4,6 @@ mod helpers;
 
 use frost_secp256k1_tr::SigningKey;
 use helpers::samples;
-use rand::thread_rng;
 
 #[allow(clippy::unnecessary_literal_unwrap)]
 fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: T) {
@@ -20,7 +19,7 @@ fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: 
 
 #[test]
 fn check_signing_key_common_traits() {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
     let signing_key = SigningKey::new(&mut rng);
     check_common_traits_for_type(signing_key);
 }

--- a/frost-secp256k1-tr/tests/integration_tests.rs
+++ b/frost-secp256k1-tr/tests/integration_tests.rs
@@ -1,6 +1,5 @@
 use frost_secp256k1_tr::*;
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 #[test]
@@ -10,14 +9,14 @@ fn check_zero_key_fails() {
 
 #[test]
 fn check_sign_with_dkg() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Secp256K1Sha256TR, _>(rng);
 }
 
 #[test]
 fn check_dkg_part1_fails_with_invalid_signers_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 1;
     let max_signers = 3;
@@ -31,7 +30,7 @@ fn check_dkg_part1_fails_with_invalid_signers_min_signers() {
 
 #[test]
 fn check_dkg_part1_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -45,7 +44,7 @@ fn check_dkg_part1_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_dkg_part1_fails_with_invalid_signers_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 1;
@@ -59,21 +58,21 @@ fn check_dkg_part1_fails_with_invalid_signers_max_signers() {
 
 #[test]
 fn check_rts() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::repairable::check_rts::<Secp256K1Sha256TR, _>(rng);
 }
 
 #[test]
 fn check_refresh_shares_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer::<Secp256K1Sha256TR, _>(rng);
 }
 
 #[test]
 fn check_refresh_shares_with_dealer_serialisation() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer_serialisation::<
         Secp256K1Sha256TR,
@@ -83,7 +82,7 @@ fn check_refresh_shares_with_dealer_serialisation() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_public_key_package() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer_fails_with_invalid_public_key_package::<
         Secp256K1Sha256TR,
@@ -93,7 +92,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_public_key_package() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -112,7 +111,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_unequal_num_identifiers_and_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -131,7 +130,7 @@ fn check_refresh_shares_with_dealer_fails_with_unequal_num_identifiers_and_max_s
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -150,7 +149,7 @@ fn check_refresh_shares_with_dealer_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![Identifier::try_from(1).unwrap()];
     let min_signers = 3;
     let max_signers = 1;
@@ -164,7 +163,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_max_signers() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_identifier() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(8).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -183,21 +182,21 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_identifier() {
 
 #[test]
 fn check_refresh_shares_with_dkg() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dkg::<Secp256K1Sha256TR, _>(rng);
 }
 
 #[test]
 fn check_sign_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Secp256K1Sha256TR, _>(rng);
 }
 
 #[test]
 fn check_sign_with_dealer_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 1;
     let max_signers = 3;
@@ -211,7 +210,7 @@ fn check_sign_with_dealer_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_sign_with_dealer_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -225,7 +224,7 @@ fn check_sign_with_dealer_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_sign_with_dealer_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 1;
@@ -241,13 +240,13 @@ fn check_sign_with_dealer_fails_with_invalid_max_signers() {
 /// value is working.
 #[test]
 fn check_share_generation_secp256k1_tr_sha256() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_share_generation::<Secp256K1Sha256TR, _>(rng);
 }
 
 #[test]
 fn check_share_generation_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 0;
     let max_signers = 3;
@@ -261,7 +260,7 @@ fn check_share_generation_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_share_generation_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -275,7 +274,7 @@ fn check_share_generation_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_share_generation_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 0;
@@ -339,7 +338,7 @@ fn check_identifier_generation() -> Result<(), Error> {
 
 #[test]
 fn check_sign_with_dealer_and_identifiers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer_and_identifiers::<
         Secp256K1Sha256TR,
@@ -349,7 +348,7 @@ fn check_sign_with_dealer_and_identifiers() {
 
 #[test]
 fn check_sign_with_missing_identifier() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_sign_with_missing_identifier::<
         Secp256K1Sha256TR,
         _,
@@ -358,7 +357,7 @@ fn check_sign_with_missing_identifier() {
 
 #[test]
 fn check_sign_with_incorrect_commitments() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_sign_with_incorrect_commitments::<
         Secp256K1Sha256TR,
         _,

--- a/frost-secp256k1-tr/tests/interoperability_tests.rs
+++ b/frost-secp256k1-tr/tests/interoperability_tests.rs
@@ -1,25 +1,24 @@
 use frost_secp256k1_tr::*;
 
 use crate::Secp256K1Sha256TR;
-use rand::thread_rng;
 
 mod helpers;
 
 #[test]
 fn check_interoperability_in_regular_sign() {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
 
     for _ in 0..256 {
         let signing_key = SigningKey::new(&mut rng);
         let verifying_key = signing_key.into();
-        let signature = signing_key.sign(&mut rng, b"message");
+        let signature = signing_key.sign(rng, b"message");
         helpers::verify_signature(b"message", &signature, &verifying_key);
     }
 }
 
 #[test]
 fn check_interoperability_in_sign_with_dkg() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     // Test with multiple keys/signatures to better exercise the key generation
     // and the interoperability check. A smaller number of iterations is used
@@ -27,7 +26,7 @@ fn check_interoperability_in_sign_with_dkg() {
     for _ in 0..32 {
         let (message, group_signature, group_pubkey) =
             frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Secp256K1Sha256TR, _>(
-                rng.clone(),
+                rng,
             );
 
         helpers::verify_signature(&message, &group_signature, &group_pubkey);
@@ -36,14 +35,14 @@ fn check_interoperability_in_sign_with_dkg() {
 
 #[test]
 fn check_interoperability_in_sign_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     // Test with multiple keys/signatures to better exercise the key generation
     // and the interoperability check.
     for _ in 0..256 {
         let (message, group_signature, group_pubkey) =
             frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Secp256K1Sha256TR, _>(
-                rng.clone(),
+                rng,
             );
 
         // Check that the threshold signature can be verified by the `ed25519_dalek` crate

--- a/frost-secp256k1-tr/tests/rerandomized_tests.rs
+++ b/frost-secp256k1-tr/tests/rerandomized_tests.rs
@@ -1,9 +1,8 @@
 use frost_secp256k1_tr::Secp256K1Sha256TR;
-use rand::thread_rng;
 
 #[test]
 fn check_randomized_sign_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let (_msg, _group_signature, _group_pubkey) =
         frost_rerandomized::tests::check_randomized_sign_with_dealer::<Secp256K1Sha256TR, _>(rng);

--- a/frost-secp256k1-tr/tests/tweaking_tests.rs
+++ b/frost-secp256k1-tr/tests/tweaking_tests.rs
@@ -12,19 +12,19 @@ mod helpers;
 #[test]
 fn check_tweaked_sign_with_dealer() -> Result<(), Box<dyn Error>> {
     use frost_secp256k1_tr as frost;
-    use rand::thread_rng;
+
     use std::collections::BTreeMap;
 
     let merkle_root: Vec<u8> = vec![12; 32];
 
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
     let max_signers = 5;
     let min_signers = 3;
     let (shares, pubkey_package) = frost::keys::generate_with_dealer(
         max_signers,
         min_signers,
         frost::keys::IdentifierList::Default,
-        &mut rng,
+        rng,
     )?;
     let mut key_packages: BTreeMap<_, _> = BTreeMap::new();
     for (identifier, secret_share) in shares {

--- a/frost-secp256k1/README.md
+++ b/frost-secp256k1/README.md
@@ -11,10 +11,9 @@ scenario in a single thread and it abstracts away any communication between peer
 ```rust
 # // ANCHOR: tkg_gen
 use frost_secp256k1 as frost;
-use rand::thread_rng;
 use std::collections::BTreeMap;
 
-let mut rng = thread_rng();
+let mut rng = rand::rngs::OsRng;
 let max_signers = 5;
 let min_signers = 3;
 let (shares, pubkey_package) = frost::keys::generate_with_dealer(

--- a/frost-secp256k1/benches/bench.rs
+++ b/frost-secp256k1/benches/bench.rs
@@ -1,16 +1,15 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use rand::thread_rng;
 
 use frost_secp256k1::*;
 
 fn bench_secp256k1_batch_verify(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
 
     frost_core::benches::bench_batch_verify::<Secp256K1Sha256, _>(c, "secp256k1", &mut rng);
 }
 
 fn bench_secp256k1_sign(c: &mut Criterion) {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
 
     frost_core::benches::bench_sign::<Secp256K1Sha256, _>(c, "secp256k1", &mut rng);
 }

--- a/frost-secp256k1/dkg.md
+++ b/frost-secp256k1/dkg.md
@@ -26,12 +26,11 @@ they can proceed to sign messages with FROST.
 
 ```rust
 # // ANCHOR: dkg_import
-use rand::thread_rng;
 use std::collections::BTreeMap;
 
 use frost_secp256k1 as frost;
 
-let mut rng = thread_rng();
+let mut rng = rand::rngs::OsRng;
 
 let max_signers = 5;
 let min_signers = 3;

--- a/frost-secp256k1/src/keys/repairable.rs
+++ b/frost-secp256k1/src/keys/repairable.rs
@@ -58,7 +58,7 @@ pub fn repair_share_step_3(
 mod tests {
 
     use lazy_static::lazy_static;
-    use rand::thread_rng;
+
     use serde_json::Value;
 
     use crate::Secp256K1Sha256;
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_1() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
 
         frost_core::tests::repairable::check_repair_share_step_1::<Secp256K1Sha256, _>(rng);
     }
@@ -83,7 +83,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_3() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
         frost_core::tests::repairable::check_repair_share_step_3::<Secp256K1Sha256, _>(
             rng,
             &REPAIR_SHARE,
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn check_repair_share_step_1_fails_with_invalid_min_signers() {
-        let rng = thread_rng();
+        let rng = rand::rngs::OsRng;
         frost_core::tests::repairable::check_repair_share_step_1_fails_with_invalid_min_signers::<
             Secp256K1Sha256,
             _,

--- a/frost-secp256k1/src/tests/batch.rs
+++ b/frost-secp256k1/src/tests/batch.rs
@@ -1,24 +1,22 @@
-use rand::thread_rng;
-
 use crate::*;
 
 #[test]
 fn check_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::batch_verify::<Secp256K1Sha256, _>(rng);
 }
 
 #[test]
 fn check_bad_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::bad_batch_verify::<Secp256K1Sha256, _>(rng);
 }
 
 #[test]
 fn empty_batch_verify() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::batch::empty_batch_verify::<Secp256K1Sha256, _>(rng);
 }

--- a/frost-secp256k1/src/tests/coefficient_commitment.rs
+++ b/frost-secp256k1/src/tests/coefficient_commitment.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 use crate::*;
@@ -13,7 +12,7 @@ lazy_static! {
 
 #[test]
 fn check_serialization_of_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::coefficient_commitment::check_serialization_of_coefficient_commitment::<
         Secp256K1Sha256,
         _,
@@ -22,7 +21,7 @@ fn check_serialization_of_coefficient_commitment() {
 
 #[test]
 fn check_create_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::coefficient_commitment::check_create_coefficient_commitment::<
         Secp256K1Sha256,
         _,
@@ -37,7 +36,7 @@ fn check_create_coefficient_commitment_error() {
 
 #[test]
 fn check_get_value_of_coefficient_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::coefficient_commitment::check_get_value_of_coefficient_commitment::<
         Secp256K1Sha256,

--- a/frost-secp256k1/src/tests/vss_commitment.rs
+++ b/frost-secp256k1/src/tests/vss_commitment.rs
@@ -1,5 +1,4 @@
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 use crate::*;
@@ -13,19 +12,19 @@ lazy_static! {
 
 #[test]
 fn check_serialize_vss_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_serialize_vss_commitment::<Secp256K1Sha256, _>(rng);
 }
 
 #[test]
 fn check_deserialize_vss_commitment() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_deserialize_vss_commitment::<Secp256K1Sha256, _>(rng);
 }
 
 #[test]
 fn check_deserialize_vss_commitment_error() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_deserialize_vss_commitment_error::<Secp256K1Sha256, _>(
         rng, &ELEMENTS,
     );
@@ -33,6 +32,6 @@ fn check_deserialize_vss_commitment_error() {
 
 #[test]
 fn check_compute_public_key_package() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::vss_commitment::check_compute_public_key_package::<Secp256K1Sha256, _>(rng);
 }

--- a/frost-secp256k1/tests/common_traits_tests.rs
+++ b/frost-secp256k1/tests/common_traits_tests.rs
@@ -4,7 +4,6 @@ mod helpers;
 
 use frost_secp256k1::SigningKey;
 use helpers::samples;
-use rand::thread_rng;
 
 #[allow(clippy::unnecessary_literal_unwrap)]
 fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: T) {
@@ -20,7 +19,7 @@ fn check_common_traits_for_type<T: Clone + Eq + PartialEq + std::fmt::Debug>(v: 
 
 #[test]
 fn check_signing_key_common_traits() {
-    let mut rng = thread_rng();
+    let mut rng = rand::rngs::OsRng;
     let signing_key = SigningKey::new(&mut rng);
     check_common_traits_for_type(signing_key);
 }

--- a/frost-secp256k1/tests/integration_tests.rs
+++ b/frost-secp256k1/tests/integration_tests.rs
@@ -1,6 +1,5 @@
 use frost_secp256k1::*;
 use lazy_static::lazy_static;
-use rand::thread_rng;
 use serde_json::Value;
 
 #[test]
@@ -10,14 +9,14 @@ fn check_zero_key_fails() {
 
 #[test]
 fn check_sign_with_dkg() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dkg::<Secp256K1Sha256, _>(rng);
 }
 
 #[test]
 fn check_dkg_part1_fails_with_invalid_signers_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 1;
     let max_signers = 3;
@@ -31,7 +30,7 @@ fn check_dkg_part1_fails_with_invalid_signers_min_signers() {
 
 #[test]
 fn check_dkg_part1_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -45,7 +44,7 @@ fn check_dkg_part1_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_dkg_part1_fails_with_invalid_signers_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 1;
@@ -59,21 +58,21 @@ fn check_dkg_part1_fails_with_invalid_signers_max_signers() {
 
 #[test]
 fn check_rts() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::repairable::check_rts::<Secp256K1Sha256, _>(rng);
 }
 
 #[test]
 fn check_refresh_shares_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer::<Secp256K1Sha256, _>(rng);
 }
 
 #[test]
 fn check_refresh_shares_with_dealer_serialisation() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer_serialisation::<Secp256K1Sha256, _>(
         rng,
@@ -82,7 +81,7 @@ fn check_refresh_shares_with_dealer_serialisation() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_public_key_package() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dealer_fails_with_invalid_public_key_package::<
         Secp256K1Sha256,
@@ -92,7 +91,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_public_key_package() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -111,7 +110,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_unequal_num_identifiers_and_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -130,7 +129,7 @@ fn check_refresh_shares_with_dealer_fails_with_unequal_num_identifiers_and_max_s
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(1).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -149,7 +148,7 @@ fn check_refresh_shares_with_dealer_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![Identifier::try_from(1).unwrap()];
     let min_signers = 3;
     let max_signers = 1;
@@ -163,7 +162,7 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_max_signers() {
 
 #[test]
 fn check_refresh_shares_with_dealer_fails_with_invalid_identifier() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     let identifiers = vec![
         Identifier::try_from(8).unwrap(),
         Identifier::try_from(3).unwrap(),
@@ -182,21 +181,21 @@ fn check_refresh_shares_with_dealer_fails_with_invalid_identifier() {
 
 #[test]
 fn check_refresh_shares_with_dkg() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::refresh::check_refresh_shares_with_dkg::<Secp256K1Sha256, _>(rng);
 }
 
 #[test]
 fn check_sign_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer::<Secp256K1Sha256, _>(rng);
 }
 
 #[test]
 fn check_sign_with_dealer_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 1;
     let max_signers = 3;
@@ -210,7 +209,7 @@ fn check_sign_with_dealer_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_sign_with_dealer_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -224,7 +223,7 @@ fn check_sign_with_dealer_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_sign_with_dealer_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 1;
@@ -240,13 +239,13 @@ fn check_sign_with_dealer_fails_with_invalid_max_signers() {
 /// value is working.
 #[test]
 fn check_share_generation_secp256k1_sha256() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_share_generation::<Secp256K1Sha256, _>(rng);
 }
 
 #[test]
 fn check_share_generation_fails_with_invalid_min_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 0;
     let max_signers = 3;
@@ -260,7 +259,7 @@ fn check_share_generation_fails_with_invalid_min_signers() {
 
 #[test]
 fn check_share_generation_fails_with_min_signers_greater_than_max() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 2;
@@ -274,7 +273,7 @@ fn check_share_generation_fails_with_min_signers_greater_than_max() {
 
 #[test]
 fn check_share_generation_fails_with_invalid_max_signers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let min_signers = 3;
     let max_signers = 0;
@@ -338,7 +337,7 @@ fn check_identifier_generation() -> Result<(), Error> {
 
 #[test]
 fn check_sign_with_dealer_and_identifiers() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     frost_core::tests::ciphersuite_generic::check_sign_with_dealer_and_identifiers::<
         Secp256K1Sha256,
@@ -348,7 +347,7 @@ fn check_sign_with_dealer_and_identifiers() {
 
 #[test]
 fn check_sign_with_missing_identifier() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_sign_with_missing_identifier::<Secp256K1Sha256, _>(
         rng,
     );
@@ -356,7 +355,7 @@ fn check_sign_with_missing_identifier() {
 
 #[test]
 fn check_sign_with_incorrect_commitments() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
     frost_core::tests::ciphersuite_generic::check_sign_with_incorrect_commitments::<
         Secp256K1Sha256,
         _,

--- a/frost-secp256k1/tests/rerandomized_tests.rs
+++ b/frost-secp256k1/tests/rerandomized_tests.rs
@@ -1,9 +1,8 @@
 use frost_secp256k1::Secp256K1Sha256;
-use rand::thread_rng;
 
 #[test]
 fn check_randomized_sign_with_dealer() {
-    let rng = thread_rng();
+    let rng = rand::rngs::OsRng;
 
     let (_msg, _group_signature, _group_pubkey) =
         frost_rerandomized::tests::check_randomized_sign_with_dealer::<Secp256K1Sha256, _>(rng);


### PR DESCRIPTION
While our libraries don't do RNG directly and take an CryptoRng from the caller, we do have a bunch of tests and examples that do RNG and that people will inevitably copy.

Reading [`rand`s CHANGELOG](https://github.com/rust-random/rand/blob/c01aee7a138ff77657782069771bb11f120318d7/CHANGELOG.md) while reviewing #853, I noticed that it has a new `"rand is not a crypto library"` policy. Its `thread_rng` that we were using is also not fork-safe. Looking for alternatives I saw that librustzcash uses `OsRng`, which seems to be the right thing to do (even if it's still in `rand`, but it's basically a `getrandom()` wrapper that implements `CryptoRng`, which is exactly what we need).

This changes all usages of `thread_rng()` to use `OsRng` instead.