### PR TITLE
docs: Add network topologies section with diagrams

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -2,6 +2,7 @@
 
 [ZF FROST](index.md)
 - [Understanding FROST](frost.md)
+  - [Network Topologies](frost.md#network-topologies)
 - [Tutorial](tutorial.md)
   - [Importing and General Information](tutorial/importing.md)
   - [Trusted Dealer Key Generation](tutorial/trusted-dealer.md)

--- a/book/src/frost.md
+++ b/book/src/frost.md
@@ -153,14 +153,6 @@ Alternative DKG setup:
 - Hub must be trusted for message delivery (but cannot learn secrets)
 - May be suitable for controlled environments
 
-```admonish warning
-The choice of topology can significantly impact the security and performance of your FROST implementation. Consider your specific requirements around trust, network capabilities, and fault tolerance when choosing a topology.
-```
-
-```admonish note
-For high-security applications, it's recommended to use the Full Mesh topology for DKG and either Distributed Coordination or Centralized Coordinator (with backup coordinators) for signing.
-```
-
 ## Verifying Signatures
 
 Signature verification is carried out as normal with single-party signatures,

--- a/book/src/frost.md
+++ b/book/src/frost.md
@@ -78,6 +78,89 @@ be able to produce the final signature. Of course, the Coordinator
 is still free to start the process with only 2 participants if they wish.
 ```
 
+## Network Topologies
+
+FROST supports different network topologies for both signing and DKG (Distributed Key Generation) processes. Understanding these topologies is crucial for implementing FROST in a way that best suits your application's needs.
+
+### Signing Topologies
+
+#### 1. Centralized Coordinator
+
+```ascii
+           Coordinator
+           /    |    \
+          /     |     \
+         /      |      \
+    Signer1  Signer2  Signer3
+```
+
+This is the default topology where:
+- A single coordinator (which may or may not be a signer) manages the signing process
+- Signers only communicate with the coordinator
+- Pros: Simple to implement, clear communication flow
+- Cons: Single point of failure, potential bottleneck
+
+#### 2. Distributed Coordination
+
+```ascii
+    Signer1 -------- Signer2
+        \           /
+         \         /
+          \       /
+           Signer3
+```
+
+In this topology:
+- Each signer acts as their own coordinator
+- All signers communicate directly with each other
+- Pros: No single point of failure
+- Cons: More complex implementation, requires full mesh networking
+
+### DKG Topologies
+
+#### 1. Full Mesh (Recommended)
+
+```ascii
+    Node1 --------- Node2
+      | \         / |
+      |  \       /  |
+      |   \     /   |
+      |    \   /    |
+      |     \ /     |
+    Node4 --- Node3
+```
+
+For DKG:
+- All participants need to communicate directly with each other
+- Requires authenticated and confidential channels between all pairs
+- Requires a broadcast channel for public values
+- Most secure but requires more complex networking setup
+
+#### 2. Star with Broadcast Hub
+
+```ascii
+           Hub
+         / | \
+        /  |  \
+    Node1  |  Node3
+           |
+         Node2
+```
+
+Alternative DKG setup:
+- A central hub relays messages between participants
+- Simpler networking requirements
+- Hub must be trusted for message delivery (but cannot learn secrets)
+- May be suitable for controlled environments
+
+```admonish warning
+The choice of topology can significantly impact the security and performance of your FROST implementation. Consider your specific requirements around trust, network capabilities, and fault tolerance when choosing a topology.
+```
+
+```admonish note
+For high-security applications, it's recommended to use the Full Mesh topology for DKG and either Distributed Coordination or Centralized Coordinator (with backup coordinators) for signing.
+```
+
 ## Verifying Signatures
 
 Signature verification is carried out as normal with single-party signatures,


### PR DESCRIPTION
Resolves #722

Added a new section to the documentation that explains FROST network topologies:
- Signing topologies (Centralized and Distributed)
- DKG topologies (Full Mesh and Star)
- ASCII diagrams for visual representation
- Pros and cons for each topology
- Guidelines for topology selection

Changes:
- Added "Network Topologies" section in frost.md
- Updated SUMMARY.md with new section link