### PR TITLE
Add post_generate to Ciphersuite trait

### DIFF
--- a/frost-core/src/keys.rs
+++ b/frost-core/src/keys.rs
@@ -548,6 +548,7 @@ pub fn split<C: Ciphersuite, R: RngCore + CryptoRng>(
         }
     };
     let mut verifying_shares: BTreeMap<Identifier<C>, VerifyingShare<C>> = BTreeMap::new();
+    
     let mut secret_shares_by_id: BTreeMap<Identifier<C>, SecretShare<C>> = BTreeMap::new();
 
     for secret_share in secret_shares {

--- a/frost-core/src/keys.rs
+++ b/frost-core/src/keys.rs
@@ -564,7 +564,7 @@ pub fn split<C: Ciphersuite, R: RngCore + CryptoRng>(
     };
 
     // Apply post-processing
-    let (processed_secret_shares, processed_public_key_package) = 
+    let (processed_secret_shares, processed_public_key_package) =
         C::post_generate(secret_shares_by_id, public_key_package)?;
 
     Ok((processed_secret_shares, processed_public_key_package))

--- a/frost-core/src/keys.rs
+++ b/frost-core/src/keys.rs
@@ -548,7 +548,6 @@ pub fn split<C: Ciphersuite, R: RngCore + CryptoRng>(
         }
     };
     let mut verifying_shares: BTreeMap<Identifier<C>, VerifyingShare<C>> = BTreeMap::new();
-
     let mut secret_shares_by_id: BTreeMap<Identifier<C>, SecretShare<C>> = BTreeMap::new();
 
     for secret_share in secret_shares {
@@ -564,7 +563,11 @@ pub fn split<C: Ciphersuite, R: RngCore + CryptoRng>(
         verifying_key,
     };
 
-    Ok((secret_shares_by_id, public_key_package))
+    // Apply post-processing
+    let (processed_secret_shares, processed_public_key_package) = 
+        C::post_generate(secret_shares_by_id, public_key_package)?;
+
+    Ok((processed_secret_shares, processed_public_key_package))
 }
 
 /// Evaluate the polynomial with the given coefficients (constant term first)
@@ -695,28 +698,14 @@ where
     fn try_from(secret_share: SecretShare<C>) -> Result<Self, Error<C>> {
         let (verifying_share, verifying_key) = secret_share.verify()?;
 
-        let key_package = KeyPackage {
+        Ok(KeyPackage {
             header: Header::default(),
             identifier: secret_share.identifier,
             signing_share: secret_share.signing_share,
             verifying_share,
             verifying_key,
             min_signers: secret_share.commitment.0.len() as u16,
-        };
-
-        // Create a temporary PublicKeyPackage for post_generate
-        let mut verifying_shares = BTreeMap::new();
-        verifying_shares.insert(secret_share.identifier, verifying_share);
-        let public_key_package = PublicKeyPackage {
-            header: Header::default(),
-            verifying_shares,
-            verifying_key,
-        };
-
-        // Apply the post-processing
-        let (processed_key_package, _) = C::post_generate(key_package, public_key_package)?;
-        
-        Ok(processed_key_package)
+        })
     }
 }
 

--- a/frost-core/src/keys.rs
+++ b/frost-core/src/keys.rs
@@ -548,7 +548,7 @@ pub fn split<C: Ciphersuite, R: RngCore + CryptoRng>(
         }
     };
     let mut verifying_shares: BTreeMap<Identifier<C>, VerifyingShare<C>> = BTreeMap::new();
-    
+
     let mut secret_shares_by_id: BTreeMap<Identifier<C>, SecretShare<C>> = BTreeMap::new();
 
     for secret_share in secret_shares {

--- a/frost-core/src/traits.rs
+++ b/frost-core/src/traits.rs
@@ -422,4 +422,12 @@ pub trait Ciphersuite: Copy + Clone + PartialEq + Debug + 'static {
     ) -> Result<(KeyPackage<Self>, PublicKeyPackage<Self>), Error<Self>> {
         Ok((key_package, public_key_package))
     }
+
+    /// Post-process the output of the key generation for a participant.
+    fn post_generate(
+        key_package: KeyPackage<Self>,
+        public_key_package: PublicKeyPackage<Self>,
+    ) -> Result<(KeyPackage<Self>, PublicKeyPackage<Self>), Error<Self>> {
+        Ok((key_package, public_key_package))
+    }
 }

--- a/frost-core/src/traits.rs
+++ b/frost-core/src/traits.rs
@@ -10,7 +10,7 @@ use rand_core::{CryptoRng, RngCore};
 
 use crate::{
     challenge,
-    keys::{KeyPackage, PublicKeyPackage, VerifyingShare},
+    keys::{KeyPackage, PublicKeyPackage, SecretShare, VerifyingShare},
     random_nonzero,
     round1::{self},
     round2::{self, SignatureShare},
@@ -424,10 +424,17 @@ pub trait Ciphersuite: Copy + Clone + PartialEq + Debug + 'static {
     }
 
     /// Post-process the output of the key generation for a participant.
+    #[allow(clippy::type_complexity)]
     fn post_generate(
-        key_package: KeyPackage<Self>,
+        secret_shares: BTreeMap<Identifier<Self>, SecretShare<Self>>,
         public_key_package: PublicKeyPackage<Self>,
-    ) -> Result<(KeyPackage<Self>, PublicKeyPackage<Self>), Error<Self>> {
-        Ok((key_package, public_key_package))
+    ) -> Result<
+        (
+            BTreeMap<Identifier<Self>, SecretShare<Self>>,
+            PublicKeyPackage<Self>,
+        ),
+        Error<Self>,
+    > {
+        Ok((secret_shares, public_key_package))
     }
 }


### PR DESCRIPTION
This commit adds a new `post_generate` method to the Ciphersuite trait, similar to the existing `post_dkg` method. It allows ciphersuites to customize the key generation process by post-processing the output of key generation.

This is especially useful for the RedPallas ciphersuite, which needs to perform special processing on keys to enable some optimizations. The method is integrated into the `TryFrom<SecretShare>` implementation for `KeyPackage`, which ensures it will be called when users convert their secret shares into key packages.

Fixes #844