### PR TITLE
chore(frost-core): import `String` from `alloc`

### DIFF
--- a/frost-core/src/tests/vectors_dkg.rs
+++ b/frost-core/src/tests/vectors_dkg.rs
@@ -1,5 +1,9 @@
 //! Helper function for testing with test vectors.
-use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+    vec::Vec,
+};
 use debugless_unwrap::DebuglessUnwrap;
 use hex::{self};
 use serde_json::Value;


### PR DESCRIPTION
my `#![no_std]` fork can no longer pass CI because of this:
```
    Compiling frost-core v2.1.0 (/home/runner/work/frost/frost/frost-core)
 error[E0412]: cannot find type `String` in this scope
   --> frost-core/src/tests/vectors_dkg.rs:156:18
    |
156 |     sender_num: &String,
    |                  ^^^^^^
```

@conradoplg 
