### PR TITLE
feat: bump MSRV to Rust 1.73

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - run: cargo build
 
   build_msrv:
-    name: build with MSRV (1.66.1)
+    name: build with MSRV (1.73)
     runs-on: ubuntu-latest
 
     steps:
@@ -34,7 +34,7 @@ jobs:
       - run: cargo update -Z minimal-versions
       # Now check that `cargo build` works with respect to the oldest possible
       # deps and the stated MSRV
-      - uses: dtolnay/rust-toolchain@1.66.1
+      - uses: dtolnay/rust-toolchain@1.73
       - run: cargo build --all-features
 
   # TODO: this is filling up the disk space in CI. See if there is a way to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
+rust-version = "1.73"
 version = "2.1.0"
 authors = [
     "Deirdre Connolly <durumcrustulum@gmail.com>",

--- a/frost-core/CHANGELOG.md
+++ b/frost-core/CHANGELOG.md
@@ -4,6 +4,8 @@ Entries are listed in reverse chronological order.
 
 ## Unreleased
 
+* MSRV has been bumped to Rust 1.73
+
 ## 2.1.0
 
 * It is now possible to identify the culprit in `frost_core::keys::dkg::part3()`

--- a/frost-core/Cargo.toml
+++ b/frost-core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "frost-core"
 edition.workspace = true
+rust-version.workspace = true
 version.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/frost-core/src/scalar_mul.rs
+++ b/frost-core/src/scalar_mul.rs
@@ -14,27 +14,6 @@ use alloc::vec::Vec;
 
 use crate::{Ciphersuite, Element, Field, Group, Scalar};
 
-/// Calculates the quotient of `self` and `rhs`, rounding the result towards positive infinity.
-///
-/// # Panics
-///
-/// This function will panic if `rhs` is 0 or the division results in overflow.
-///
-/// This function is similar to `div_ceil` that is [available on
-/// Nightly](https://github.com/rust-lang/rust/issues/88581).
-///
-// TODO: remove this function and use `div_ceil()` instead when `int_roundings`
-// is stabilized.
-const fn div_ceil(lhs: usize, rhs: usize) -> usize {
-    let d = lhs / rhs;
-    let r = lhs % rhs;
-    if r > 0 && rhs > 0 {
-        d + 1
-    } else {
-        d
-    }
-}
-
 /// A trait for transforming a scalar generic over a ciphersuite to a non-adjacent form (NAF).
 pub trait NonAdjacentForm<C: Ciphersuite> {
     fn non_adjacent_form(&self, w: usize) -> Vec<i8>;
@@ -81,7 +60,7 @@ where
         let mut naf = vec![0; naf_length];
 
         // Get the number of 64-bit limbs we need.
-        let num_limbs: usize = div_ceil(naf_length, u64::BITS as usize);
+        let num_limbs: usize = naf_length.div_ceil(u64::BITS as usize);
 
         let mut x_u64 = vec![0u64; num_limbs];
 

--- a/frost-core/src/tests/vss_commitment.rs
+++ b/frost-core/src/tests/vss_commitment.rs
@@ -5,6 +5,7 @@ use crate::{
     tests::helpers::generate_element,
     Error, Group,
 };
+use alloc::vec::Vec;
 use debugless_unwrap::DebuglessUnwrap;
 use rand_core::{CryptoRng, RngCore};
 use serde_json::Value;

--- a/frost-ed25519/Cargo.toml
+++ b/frost-ed25519/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "frost-ed25519"
 edition.workspace = true
+rust-version.workspace = true
 version.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/frost-ed448/Cargo.toml
+++ b/frost-ed448/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "frost-ed448"
 edition.workspace = true
+rust-version.workspace = true
 version.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/frost-ed448/src/lib.rs
+++ b/frost-ed448/src/lib.rs
@@ -7,7 +7,7 @@
 
 extern crate alloc;
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use ed448_goldilocks::{
     curve::{edwards::CompressedEdwardsY, ExtendedPoint},

--- a/frost-p256/Cargo.toml
+++ b/frost-p256/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "frost-p256"
 edition.workspace = true
+rust-version.workspace = true
 version.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/frost-rerandomized/Cargo.toml
+++ b/frost-rerandomized/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "frost-rerandomized"
 edition.workspace = true
+rust-version.workspace = true
 version.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/frost-ristretto255/Cargo.toml
+++ b/frost-ristretto255/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "frost-ristretto255"
 edition.workspace = true
+rust-version.workspace = true
 version.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/frost-secp256k1-tr/Cargo.toml
+++ b/frost-secp256k1-tr/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "frost-secp256k1-tr"
 edition.workspace = true
+rust-version.workspace = true
 version.workspace = true
 authors.workspace = true
 readme = "README.md"

--- a/frost-secp256k1/Cargo.toml
+++ b/frost-secp256k1/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "frost-secp256k1"
 edition.workspace = true
+rust-version.workspace = true
 version.workspace = true
 authors.workspace = true
 readme = "README.md"


### PR DESCRIPTION
Resolves #768
@conradoplg Let's start at least with this change. I haven't bumped MSRV to Rust 1.81 yet, although we could do that to get rid of `thiserror-nostd-notrait` in favor of `thiserror`. I'd also keep `lazy_static` since it works in `#![no_std]` crates.
