### PR TITLE
core: remove unused error

### DIFF
--- a/frost-core/src/error.rs
+++ b/frost-core/src/error.rs
@@ -3,9 +3,6 @@
 use crate::{Ciphersuite, Identifier};
 use thiserror::Error;
 
-#[derive(Error, Debug, Clone, Copy, Eq, PartialEq)]
-pub struct ParticipantError<C: Ciphersuite>(Identifier<C>);
-
 /// An error related to FROST.
 #[non_exhaustive]
 #[derive(Error, Debug, Copy, Clone, Eq, PartialEq)]


### PR DESCRIPTION
No idea why clippy is only catching this now, but we have a error struct that was not being used.