### PR TITLE
core: add aggregate_custom

### DIFF
--- a/frost-core/src/round2.rs
+++ b/frost-core/src/round2.rs
@@ -74,7 +74,7 @@ where
                 + (verifying_share.to_element() * challenge.0 * lambda_i))
         {
             return Err(Error::InvalidSignatureShare {
-                culprit: identifier,
+                culprits: vec![identifier],
             });
         }
 

--- a/frost-ed25519/src/lib.rs
+++ b/frost-ed25519/src/lib.rs
@@ -419,6 +419,25 @@ pub fn aggregate(
     frost::aggregate(signing_package, signature_shares, pubkeys)
 }
 
+/// The type of cheater detection to use.
+pub type CheaterDetection = frost::CheaterDetection;
+
+/// Like [`aggregate()`], but allow specifying a specific cheater detection
+/// strategy.
+pub fn aggregate_custom(
+    signing_package: &SigningPackage,
+    signature_shares: &BTreeMap<Identifier, round2::SignatureShare>,
+    pubkeys: &keys::PublicKeyPackage,
+    cheater_detection: CheaterDetection,
+) -> Result<Signature, Error> {
+    frost::aggregate_custom(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        cheater_detection,
+    )
+}
+
 /// A signing key for a Schnorr signature on FROST(Ed25519, SHA-512).
 pub type SigningKey = frost_core::SigningKey<E>;
 

--- a/frost-ed448/src/lib.rs
+++ b/frost-ed448/src/lib.rs
@@ -413,6 +413,25 @@ pub fn aggregate(
     frost::aggregate(signing_package, signature_shares, pubkeys)
 }
 
+/// The type of cheater detection to use.
+pub type CheaterDetection = frost::CheaterDetection;
+
+/// Like [`aggregate()`], but allow specifying a specific cheater detection
+/// strategy.
+pub fn aggregate_custom(
+    signing_package: &SigningPackage,
+    signature_shares: &BTreeMap<Identifier, round2::SignatureShare>,
+    pubkeys: &keys::PublicKeyPackage,
+    cheater_detection: CheaterDetection,
+) -> Result<Signature, Error> {
+    frost::aggregate_custom(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        cheater_detection,
+    )
+}
+
 /// A signing key for a Schnorr signature on FROST(Ed448, SHAKE256).
 pub type SigningKey = frost_core::SigningKey<E>;
 

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -429,6 +429,25 @@ pub fn aggregate(
     frost::aggregate(signing_package, signature_shares, pubkeys)
 }
 
+/// The type of cheater detection to use.
+pub type CheaterDetection = frost::CheaterDetection;
+
+/// Like [`aggregate()`], but allow specifying a specific cheater detection
+/// strategy.
+pub fn aggregate_custom(
+    signing_package: &SigningPackage,
+    signature_shares: &BTreeMap<Identifier, round2::SignatureShare>,
+    pubkeys: &keys::PublicKeyPackage,
+    cheater_detection: CheaterDetection,
+) -> Result<Signature, Error> {
+    frost::aggregate_custom(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        cheater_detection,
+    )
+}
+
 /// A signing key for a Schnorr signature on FROST(P-256, SHA-256).
 pub type SigningKey = frost_core::SigningKey<P>;
 

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -405,6 +405,25 @@ pub fn aggregate(
     frost::aggregate(signing_package, signature_shares, pubkeys)
 }
 
+/// The type of cheater detection to use.
+pub type CheaterDetection = frost::CheaterDetection;
+
+/// Like [`aggregate()`], but allow specifying a specific cheater detection
+/// strategy.
+pub fn aggregate_custom(
+    signing_package: &SigningPackage,
+    signature_shares: &BTreeMap<Identifier, round2::SignatureShare>,
+    pubkeys: &keys::PublicKeyPackage,
+    cheater_detection: CheaterDetection,
+) -> Result<Signature, Error> {
+    frost::aggregate_custom(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        cheater_detection,
+    )
+}
+
 /// A signing key for a Schnorr signature on FROST(ristretto255, SHA-512).
 pub type SigningKey = frost_core::SigningKey<R>;
 

--- a/frost-secp256k1/src/lib.rs
+++ b/frost-secp256k1/src/lib.rs
@@ -429,6 +429,25 @@ pub fn aggregate(
     frost::aggregate(signing_package, signature_shares, pubkeys)
 }
 
+/// The type of cheater detection to use.
+pub type CheaterDetection = frost::CheaterDetection;
+
+/// Like [`aggregate()`], but allow specifying a specific cheater detection
+/// strategy.
+pub fn aggregate_custom(
+    signing_package: &SigningPackage,
+    signature_shares: &BTreeMap<Identifier, round2::SignatureShare>,
+    pubkeys: &keys::PublicKeyPackage,
+    cheater_detection: CheaterDetection,
+) -> Result<Signature, Error> {
+    frost::aggregate_custom(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        cheater_detection,
+    )
+}
+
 /// A signing key for a Schnorr signature on FROST(secp256k1, SHA-256).
 pub type SigningKey = frost_core::SigningKey<S>;
 


### PR DESCRIPTION
Closes https://github.com/ZcashFoundation/frost/issues/698

Draft for now because we want to do a release first.

Thinking about it, I figured we didn't need to change the `signature_shares` to be a set when detection is disabled. I think it's likely that coordinators will have the participant identifiers even if they don't have their verifying shares.

To be determined: should we remove the `cheater-detection` feature altogether? (I vote yes)