### PR TITLE
core: bind traits to Send + Sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,7 @@ dependencies = [
  "serde_json",
  "serdect",
  "thiserror",
+ "tokio",
  "visibility",
  "zeroize",
 ]
@@ -570,6 +571,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde_json",
  "sha2",
+ "tokio",
 ]
 
 [[package]]
@@ -590,6 +592,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde_json",
  "sha3",
+ "tokio",
 ]
 
 [[package]]
@@ -610,6 +613,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde_json",
  "sha2",
+ "tokio",
 ]
 
 [[package]]
@@ -642,6 +646,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde_json",
  "sha2",
+ "tokio",
 ]
 
 [[package]]
@@ -662,6 +667,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde_json",
  "sha2",
+ "tokio",
 ]
 
 [[package]]
@@ -683,6 +689,7 @@ dependencies = [
  "secp256k1",
  "serde_json",
  "sha2",
+ "tokio",
 ]
 
 [[package]]
@@ -930,6 +937,12 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pkcs8"
@@ -1444,6 +1457,27 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokio"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+dependencies = [
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ members = [
 ]
 
 [workspace.package]
+# If you update the edition, make sure to also update the argument to rustfmt
+# in gencode/src/main.rs.
 edition = "2021"
 rust-version = "1.81"
 version = "2.2.0"
@@ -37,6 +39,7 @@ rand = "0.8"
 rand_chacha = "0.3"
 rand_core = "0.6"
 serde_json = "1.0"
+tokio = { version = "1.0", features = ["rt", "time", "macros"] }
 
 frost-core = { path = "frost-core", version = "2.2.0", default-features = false }
 frost-rerandomized = { path = "frost-rerandomized", version = "2.2.0", default-features = false }

--- a/frost-core/Cargo.toml
+++ b/frost-core/Cargo.toml
@@ -35,6 +35,7 @@ itertools = { version = "0.14.0", default-features = false }
 proptest = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 criterion = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion.workspace = true
@@ -43,6 +44,7 @@ proptest.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
 serde_json.workspace = true
+
 
 [features]
 default = ["serialization", "std"]
@@ -59,7 +61,7 @@ internals = []
 serde = ["dep:serde", "dep:serdect"]
 serialization = ["serde", "dep:postcard"]
 # Exposes ciphersuite-generic tests for other crates to use
-test-impl = ["dep:proptest", "dep:serde_json", "dep:criterion"]
+test-impl = ["dep:proptest", "dep:serde_json", "dep:criterion", "dep:tokio"]
 
 [lib]
 bench = false

--- a/frost-core/src/traits.rs
+++ b/frost-core/src/traits.rs
@@ -34,7 +34,9 @@ pub trait Field: Copy {
         + Eq
         + Mul<Output = Self::Scalar>
         + PartialEq
-        + Sub<Output = Self::Scalar>;
+        + Sub<Output = Self::Scalar>
+        + Send
+        + Sync;
 
     /// A unique byte array buf of fixed length N.
     type Serialization: Clone + AsRef<[u8]> + AsMut<[u8]> + for<'a> TryFrom<&'a [u8]> + Debug;
@@ -97,7 +99,9 @@ pub trait Group: Copy + PartialEq {
         + Eq
         + Mul<<Self::Field as Field>::Scalar, Output = Self::Element>
         + PartialEq
-        + Sub<Output = Self::Element>;
+        + Sub<Output = Self::Element>
+        + Send
+        + Sync;
 
     /// A unique byte array buf of fixed length N.
     ///
@@ -147,7 +151,7 @@ pub type Element<C> = <<C as Ciphersuite>::Group as Group>::Element;
 ///
 /// [FROST ciphersuite]: https://datatracker.ietf.org/doc/html/rfc9591#name-ciphersuites
 // See https://github.com/ZcashFoundation/frost/issues/693 for reasoning about the 'static bound.
-pub trait Ciphersuite: Copy + PartialEq + Debug + 'static {
+pub trait Ciphersuite: Copy + PartialEq + Debug + 'static + Send + Sync {
     /// The ciphersuite ID string. It should be equal to the contextString in
     /// the spec. For new ciphersuites, this should be a string that identifies
     /// the ciphersuite; it's recommended to use a similar format to the

--- a/frost-ed25519/Cargo.toml
+++ b/frost-ed25519/Cargo.toml
@@ -35,6 +35,7 @@ proptest.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
 serde_json.workspace = true
+tokio.workspace = true
 
 [features]
 default = ["serialization", "std"]

--- a/frost-ed25519/tests/integration_tests.rs
+++ b/frost-ed25519/tests/integration_tests.rs
@@ -379,3 +379,13 @@ fn check_sign_with_incorrect_commitments() {
         rng,
     );
 }
+
+#[tokio::test]
+async fn check_async_sign_with_dealer() {
+    tokio::spawn(async {
+        let rng = rand::rngs::OsRng;
+        frost_core::tests::ciphersuite_generic::async_check_sign::<Ed25519Sha512, _>(rng).await;
+    })
+    .await
+    .unwrap();
+}

--- a/frost-ed448/Cargo.toml
+++ b/frost-ed448/Cargo.toml
@@ -34,6 +34,7 @@ proptest.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
 serde_json.workspace = true
+tokio.workspace = true
 
 [features]
 default = ["serialization", "std"]

--- a/frost-ed448/tests/integration_tests.rs
+++ b/frost-ed448/tests/integration_tests.rs
@@ -379,3 +379,13 @@ fn check_sign_with_incorrect_commitments() {
         rng,
     );
 }
+
+#[tokio::test]
+async fn check_async_sign_with_dealer() {
+    tokio::spawn(async {
+        let rng = rand::rngs::OsRng;
+        frost_core::tests::ciphersuite_generic::async_check_sign::<Ed448Shake256, _>(rng).await;
+    })
+    .await
+    .unwrap();
+}

--- a/frost-p256/Cargo.toml
+++ b/frost-p256/Cargo.toml
@@ -34,6 +34,7 @@ proptest.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
 serde_json.workspace = true
+tokio.workspace = true
 
 [features]
 default = ["serialization", "std"]

--- a/frost-p256/tests/integration_tests.rs
+++ b/frost-p256/tests/integration_tests.rs
@@ -376,3 +376,13 @@ fn check_sign_with_incorrect_commitments() {
         rng,
     );
 }
+
+#[tokio::test]
+async fn check_async_sign_with_dealer() {
+    tokio::spawn(async {
+        let rng = rand::rngs::OsRng;
+        frost_core::tests::ciphersuite_generic::async_check_sign::<P256Sha256, _>(rng).await;
+    })
+    .await
+    .unwrap();
+}

--- a/frost-ristretto255/Cargo.toml
+++ b/frost-ristretto255/Cargo.toml
@@ -35,6 +35,7 @@ proptest.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
 serde_json.workspace = true
+tokio.workspace = true
 
 [features]
 default = ["serialization", "std"]

--- a/frost-ristretto255/tests/integration_tests.rs
+++ b/frost-ristretto255/tests/integration_tests.rs
@@ -383,3 +383,14 @@ fn check_sign_with_incorrect_commitments() {
         _,
     >(rng);
 }
+
+#[tokio::test]
+async fn check_async_sign_with_dealer() {
+    tokio::spawn(async {
+        let rng = rand::rngs::OsRng;
+        frost_core::tests::ciphersuite_generic::async_check_sign::<Ristretto255Sha512, _>(rng)
+            .await;
+    })
+    .await
+    .unwrap();
+}

--- a/frost-secp256k1-tr/Cargo.toml
+++ b/frost-secp256k1-tr/Cargo.toml
@@ -35,6 +35,7 @@ rand.workspace = true
 rand_chacha.workspace = true
 secp256k1 = "0.31.0"
 serde_json.workspace = true
+tokio.workspace = true
 
 [features]
 default = ["serialization", "std"]

--- a/frost-secp256k1-tr/tests/integration_tests.rs
+++ b/frost-secp256k1-tr/tests/integration_tests.rs
@@ -383,3 +383,13 @@ fn check_sign_with_incorrect_commitments() {
         _,
     >(rng);
 }
+
+#[tokio::test]
+async fn check_async_sign_with_dealer() {
+    tokio::spawn(async {
+        let rng = rand::rngs::OsRng;
+        frost_core::tests::ciphersuite_generic::async_check_sign::<Secp256K1Sha256TR, _>(rng).await;
+    })
+    .await
+    .unwrap();
+}

--- a/frost-secp256k1/Cargo.toml
+++ b/frost-secp256k1/Cargo.toml
@@ -34,6 +34,7 @@ proptest.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
 serde_json.workspace = true
+tokio.workspace = true
 
 [features]
 default = ["serialization", "std"]

--- a/frost-secp256k1/tests/integration_tests.rs
+++ b/frost-secp256k1/tests/integration_tests.rs
@@ -380,3 +380,13 @@ fn check_sign_with_incorrect_commitments() {
         _,
     >(rng);
 }
+
+#[tokio::test]
+async fn check_async_sign_with_dealer() {
+    tokio::spawn(async {
+        let rng = rand::rngs::OsRng;
+        frost_core::tests::ciphersuite_generic::async_check_sign::<Secp256K1Sha256, _>(rng).await;
+    })
+    .await
+    .unwrap();
+}

--- a/gencode/src/main.rs
+++ b/gencode/src/main.rs
@@ -167,6 +167,8 @@ fn copy_and_replace(
 
 pub fn rustfmt(source: String) -> String {
     let mut child = Command::new("rustfmt")
+        .arg("--edition")
+        .arg("2021")
         .stdin(Stdio::piped())
         .stderr(Stdio::piped())
         .stdout(Stdio::piped())
@@ -181,6 +183,11 @@ pub fn rustfmt(source: String) -> String {
     });
 
     let output = child.wait_with_output().expect("Failed to read stdout");
+    assert!(
+        output.status.success(),
+        "rustfmt failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     String::from_utf8_lossy(&output.stdout).to_string()
 }
 


### PR DESCRIPTION
I had to fix gencode since it was silently failing when formatting generated code due to the introduction of `async` usage which requires bumping the Rust edition.

Closes #915