### PR TITLE
core: fix unused warning due to compiler bug

### DIFF
--- a/frost-core/src/keys.rs
+++ b/frost-core/src/keys.rs
@@ -1,5 +1,7 @@
 //! FROST keys, keygen, key shares
 #![allow(clippy::type_complexity)]
+// Remove after https://github.com/rust-lang/rust/issues/147648 is fixed
+#![allow(unused_assignments)]
 
 use core::iter;
 

--- a/frost-core/src/round1.rs
+++ b/frost-core/src/round1.rs
@@ -1,4 +1,6 @@
 //! FROST Round 1 functionality and types
+// Remove after https://github.com/rust-lang/rust/issues/147648 is fixed
+#![allow(unused_assignments)]
 
 use alloc::{
     collections::BTreeMap,


### PR DESCRIPTION
Anything that uses `#[zeroize(skip)]` gives an unused warning, but that is a bug https://github.com/rust-lang/rust/issues/147648

So just silence the warning for now