### PR TITLE
reexport rerandomized API in ciphersuite crates

### DIFF
--- a/frost-core/CHANGELOG.md
+++ b/frost-core/CHANGELOG.md
@@ -35,6 +35,8 @@ Entries are listed in reverse chronological order.
 ### Additional changes
 
 * Added DKG refresh functions to the crate-specific `refresh` modules.
+* Re-exported the `frost-rerandomized` crate in the ciphersuite functions, e.g.
+  you can call `frost_ristretto255::rerandomized::sign_with_randomizer_seed()`.
 
 ## 2.2.0
 

--- a/frost-ed25519/src/rerandomized.rs
+++ b/frost-ed25519/src/rerandomized.rs
@@ -1,0 +1,65 @@
+//! FROST implementation supporting re-randomizable keys.
+
+use alloc::collections::btree_map::BTreeMap;
+
+/// Re-randomized FROST signing using the given `randomizer_seed`, which should
+/// be sent from the Coordinator using a confidential channel.
+///
+/// See [`crate::round2::sign`] for documentation on the other parameters.
+pub fn sign_with_randomizer_seed(
+    signing_package: &crate::SigningPackage,
+    signer_nonces: &crate::round1::SigningNonces,
+    key_package: &crate::keys::KeyPackage,
+    randomizer_seed: &[u8],
+) -> Result<crate::round2::SignatureShare, crate::Error> {
+    frost_rerandomized::sign_with_randomizer_seed::<crate::Ed25519Sha512>(
+        signing_package,
+        signer_nonces,
+        key_package,
+        randomizer_seed,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`].
+///
+/// See [`frost_core::aggregate`] for documentation on the other parameters.
+pub fn aggregate(
+    signing_package: &crate::SigningPackage,
+    signature_shares: &BTreeMap<crate::Identifier, crate::round2::SignatureShare>,
+    pubkeys: &crate::keys::PublicKeyPackage,
+    randomized_params: &RandomizedParams,
+) -> Result<crate::Signature, crate::Error> {
+    frost_rerandomized::aggregate::<crate::Ed25519Sha512>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        randomized_params,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`] using the given cheater detection strategy.
+///
+/// See [`frost_core::aggregate_custom`] for documentation on the other parameters.
+pub fn aggregate_custom(
+    signing_package: &crate::SigningPackage,
+    signature_shares: &BTreeMap<crate::Identifier, crate::round2::SignatureShare>,
+    pubkeys: &crate::keys::PublicKeyPackage,
+    cheater_detection: crate::CheaterDetection,
+    randomized_params: &RandomizedParams,
+) -> Result<crate::Signature, crate::Error> {
+    frost_rerandomized::aggregate_custom::<crate::Ed25519Sha512>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        cheater_detection,
+        randomized_params,
+    )
+}
+
+/// A randomizer. A random scalar which is used to randomize the key.
+pub type Randomizer = frost_rerandomized::Randomizer<crate::Ed25519Sha512>;
+
+/// Randomized parameters for a signing instance of randomized FROST.
+pub type RandomizedParams = frost_rerandomized::RandomizedParams<crate::Ed25519Sha512>;

--- a/frost-ed448/src/rerandomized.rs
+++ b/frost-ed448/src/rerandomized.rs
@@ -1,0 +1,65 @@
+//! FROST implementation supporting re-randomizable keys.
+
+use alloc::collections::btree_map::BTreeMap;
+
+/// Re-randomized FROST signing using the given `randomizer_seed`, which should
+/// be sent from the Coordinator using a confidential channel.
+///
+/// See [`crate::round2::sign`] for documentation on the other parameters.
+pub fn sign_with_randomizer_seed(
+    signing_package: &crate::SigningPackage,
+    signer_nonces: &crate::round1::SigningNonces,
+    key_package: &crate::keys::KeyPackage,
+    randomizer_seed: &[u8],
+) -> Result<crate::round2::SignatureShare, crate::Error> {
+    frost_rerandomized::sign_with_randomizer_seed::<crate::Ed448Shake256>(
+        signing_package,
+        signer_nonces,
+        key_package,
+        randomizer_seed,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`].
+///
+/// See [`frost_core::aggregate`] for documentation on the other parameters.
+pub fn aggregate(
+    signing_package: &crate::SigningPackage,
+    signature_shares: &BTreeMap<crate::Identifier, crate::round2::SignatureShare>,
+    pubkeys: &crate::keys::PublicKeyPackage,
+    randomized_params: &RandomizedParams,
+) -> Result<crate::Signature, crate::Error> {
+    frost_rerandomized::aggregate::<crate::Ed448Shake256>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        randomized_params,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`] using the given cheater detection strategy.
+///
+/// See [`frost_core::aggregate_custom`] for documentation on the other parameters.
+pub fn aggregate_custom(
+    signing_package: &crate::SigningPackage,
+    signature_shares: &BTreeMap<crate::Identifier, crate::round2::SignatureShare>,
+    pubkeys: &crate::keys::PublicKeyPackage,
+    cheater_detection: crate::CheaterDetection,
+    randomized_params: &RandomizedParams,
+) -> Result<crate::Signature, crate::Error> {
+    frost_rerandomized::aggregate_custom::<crate::Ed448Shake256>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        cheater_detection,
+        randomized_params,
+    )
+}
+
+/// A randomizer. A random scalar which is used to randomize the key.
+pub type Randomizer = frost_rerandomized::Randomizer<crate::Ed448Shake256>;
+
+/// Randomized parameters for a signing instance of randomized FROST.
+pub type RandomizedParams = frost_rerandomized::RandomizedParams<crate::Ed448Shake256>;

--- a/frost-p256/src/rerandomized.rs
+++ b/frost-p256/src/rerandomized.rs
@@ -1,0 +1,65 @@
+//! FROST implementation supporting re-randomizable keys.
+
+use alloc::collections::btree_map::BTreeMap;
+
+/// Re-randomized FROST signing using the given `randomizer_seed`, which should
+/// be sent from the Coordinator using a confidential channel.
+///
+/// See [`crate::round2::sign`] for documentation on the other parameters.
+pub fn sign_with_randomizer_seed(
+    signing_package: &crate::SigningPackage,
+    signer_nonces: &crate::round1::SigningNonces,
+    key_package: &crate::keys::KeyPackage,
+    randomizer_seed: &[u8],
+) -> Result<crate::round2::SignatureShare, crate::Error> {
+    frost_rerandomized::sign_with_randomizer_seed::<crate::P256Sha256>(
+        signing_package,
+        signer_nonces,
+        key_package,
+        randomizer_seed,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`].
+///
+/// See [`frost_core::aggregate`] for documentation on the other parameters.
+pub fn aggregate(
+    signing_package: &crate::SigningPackage,
+    signature_shares: &BTreeMap<crate::Identifier, crate::round2::SignatureShare>,
+    pubkeys: &crate::keys::PublicKeyPackage,
+    randomized_params: &RandomizedParams,
+) -> Result<crate::Signature, crate::Error> {
+    frost_rerandomized::aggregate::<crate::P256Sha256>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        randomized_params,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`] using the given cheater detection strategy.
+///
+/// See [`frost_core::aggregate_custom`] for documentation on the other parameters.
+pub fn aggregate_custom(
+    signing_package: &crate::SigningPackage,
+    signature_shares: &BTreeMap<crate::Identifier, crate::round2::SignatureShare>,
+    pubkeys: &crate::keys::PublicKeyPackage,
+    cheater_detection: crate::CheaterDetection,
+    randomized_params: &RandomizedParams,
+) -> Result<crate::Signature, crate::Error> {
+    frost_rerandomized::aggregate_custom::<crate::P256Sha256>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        cheater_detection,
+        randomized_params,
+    )
+}
+
+/// A randomizer. A random scalar which is used to randomize the key.
+pub type Randomizer = frost_rerandomized::Randomizer<crate::P256Sha256>;
+
+/// Randomized parameters for a signing instance of randomized FROST.
+pub type RandomizedParams = frost_rerandomized::RandomizedParams<crate::P256Sha256>;

--- a/frost-ristretto255/src/lib.rs
+++ b/frost-ristretto255/src/lib.rs
@@ -22,6 +22,8 @@ use frost_core as frost;
 #[cfg(test)]
 mod tests;
 
+pub mod rerandomized;
+
 // Re-exports in our public API
 #[cfg(feature = "serde")]
 pub use frost_core::serde;

--- a/frost-ristretto255/src/rerandomized.rs
+++ b/frost-ristretto255/src/rerandomized.rs
@@ -1,0 +1,65 @@
+//! FROST implementation supporting re-randomizable keys.
+
+use alloc::collections::btree_map::BTreeMap;
+
+/// Re-randomized FROST signing using the given `randomizer_seed`, which should
+/// be sent from the Coordinator using a confidential channel.
+///
+/// See [`crate::round2::sign`] for documentation on the other parameters.
+pub fn sign_with_randomizer_seed(
+    signing_package: &crate::SigningPackage,
+    signer_nonces: &crate::round1::SigningNonces,
+    key_package: &crate::keys::KeyPackage,
+    randomizer_seed: &[u8],
+) -> Result<crate::round2::SignatureShare, crate::Error> {
+    frost_rerandomized::sign_with_randomizer_seed::<crate::Ristretto255Sha512>(
+        signing_package,
+        signer_nonces,
+        key_package,
+        randomizer_seed,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`].
+///
+/// See [`frost_core::aggregate`] for documentation on the other parameters.
+pub fn aggregate(
+    signing_package: &crate::SigningPackage,
+    signature_shares: &BTreeMap<crate::Identifier, crate::round2::SignatureShare>,
+    pubkeys: &crate::keys::PublicKeyPackage,
+    randomized_params: &RandomizedParams,
+) -> Result<crate::Signature, crate::Error> {
+    frost_rerandomized::aggregate::<crate::Ristretto255Sha512>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        randomized_params,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`] using the given cheater detection strategy.
+///
+/// See [`frost_core::aggregate_custom`] for documentation on the other parameters.
+pub fn aggregate_custom(
+    signing_package: &crate::SigningPackage,
+    signature_shares: &BTreeMap<crate::Identifier, crate::round2::SignatureShare>,
+    pubkeys: &crate::keys::PublicKeyPackage,
+    cheater_detection: crate::CheaterDetection,
+    randomized_params: &RandomizedParams,
+) -> Result<crate::Signature, crate::Error> {
+    frost_rerandomized::aggregate_custom::<crate::Ristretto255Sha512>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        cheater_detection,
+        randomized_params,
+    )
+}
+
+/// A randomizer. A random scalar which is used to randomize the key.
+pub type Randomizer = frost_rerandomized::Randomizer<crate::Ristretto255Sha512>;
+
+/// Randomized parameters for a signing instance of randomized FROST.
+pub type RandomizedParams = frost_rerandomized::RandomizedParams<crate::Ristretto255Sha512>;

--- a/frost-secp256k1-tr/src/rerandomized.rs
+++ b/frost-secp256k1-tr/src/rerandomized.rs
@@ -1,0 +1,65 @@
+//! FROST implementation supporting re-randomizable keys.
+
+use alloc::collections::btree_map::BTreeMap;
+
+/// Re-randomized FROST signing using the given `randomizer_seed`, which should
+/// be sent from the Coordinator using a confidential channel.
+///
+/// See [`crate::round2::sign`] for documentation on the other parameters.
+pub fn sign_with_randomizer_seed(
+    signing_package: &crate::SigningPackage,
+    signer_nonces: &crate::round1::SigningNonces,
+    key_package: &crate::keys::KeyPackage,
+    randomizer_seed: &[u8],
+) -> Result<crate::round2::SignatureShare, crate::Error> {
+    frost_rerandomized::sign_with_randomizer_seed::<crate::Secp256K1Sha256TR>(
+        signing_package,
+        signer_nonces,
+        key_package,
+        randomizer_seed,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`].
+///
+/// See [`frost_core::aggregate`] for documentation on the other parameters.
+pub fn aggregate(
+    signing_package: &crate::SigningPackage,
+    signature_shares: &BTreeMap<crate::Identifier, crate::round2::SignatureShare>,
+    pubkeys: &crate::keys::PublicKeyPackage,
+    randomized_params: &RandomizedParams,
+) -> Result<crate::Signature, crate::Error> {
+    frost_rerandomized::aggregate::<crate::Secp256K1Sha256TR>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        randomized_params,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`] using the given cheater detection strategy.
+///
+/// See [`frost_core::aggregate_custom`] for documentation on the other parameters.
+pub fn aggregate_custom(
+    signing_package: &crate::SigningPackage,
+    signature_shares: &BTreeMap<crate::Identifier, crate::round2::SignatureShare>,
+    pubkeys: &crate::keys::PublicKeyPackage,
+    cheater_detection: crate::CheaterDetection,
+    randomized_params: &RandomizedParams,
+) -> Result<crate::Signature, crate::Error> {
+    frost_rerandomized::aggregate_custom::<crate::Secp256K1Sha256TR>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        cheater_detection,
+        randomized_params,
+    )
+}
+
+/// A randomizer. A random scalar which is used to randomize the key.
+pub type Randomizer = frost_rerandomized::Randomizer<crate::Secp256K1Sha256TR>;
+
+/// Randomized parameters for a signing instance of randomized FROST.
+pub type RandomizedParams = frost_rerandomized::RandomizedParams<crate::Secp256K1Sha256TR>;

--- a/frost-secp256k1/src/rerandomized.rs
+++ b/frost-secp256k1/src/rerandomized.rs
@@ -1,0 +1,65 @@
+//! FROST implementation supporting re-randomizable keys.
+
+use alloc::collections::btree_map::BTreeMap;
+
+/// Re-randomized FROST signing using the given `randomizer_seed`, which should
+/// be sent from the Coordinator using a confidential channel.
+///
+/// See [`crate::round2::sign`] for documentation on the other parameters.
+pub fn sign_with_randomizer_seed(
+    signing_package: &crate::SigningPackage,
+    signer_nonces: &crate::round1::SigningNonces,
+    key_package: &crate::keys::KeyPackage,
+    randomizer_seed: &[u8],
+) -> Result<crate::round2::SignatureShare, crate::Error> {
+    frost_rerandomized::sign_with_randomizer_seed::<crate::Secp256K1Sha256>(
+        signing_package,
+        signer_nonces,
+        key_package,
+        randomizer_seed,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`].
+///
+/// See [`frost_core::aggregate`] for documentation on the other parameters.
+pub fn aggregate(
+    signing_package: &crate::SigningPackage,
+    signature_shares: &BTreeMap<crate::Identifier, crate::round2::SignatureShare>,
+    pubkeys: &crate::keys::PublicKeyPackage,
+    randomized_params: &RandomizedParams,
+) -> Result<crate::Signature, crate::Error> {
+    frost_rerandomized::aggregate::<crate::Secp256K1Sha256>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        randomized_params,
+    )
+}
+
+/// Re-randomized FROST signature share aggregation with the given
+/// [`RandomizedParams`] using the given cheater detection strategy.
+///
+/// See [`frost_core::aggregate_custom`] for documentation on the other parameters.
+pub fn aggregate_custom(
+    signing_package: &crate::SigningPackage,
+    signature_shares: &BTreeMap<crate::Identifier, crate::round2::SignatureShare>,
+    pubkeys: &crate::keys::PublicKeyPackage,
+    cheater_detection: crate::CheaterDetection,
+    randomized_params: &RandomizedParams,
+) -> Result<crate::Signature, crate::Error> {
+    frost_rerandomized::aggregate_custom::<crate::Secp256K1Sha256>(
+        signing_package,
+        signature_shares,
+        pubkeys,
+        cheater_detection,
+        randomized_params,
+    )
+}
+
+/// A randomizer. A random scalar which is used to randomize the key.
+pub type Randomizer = frost_rerandomized::Randomizer<crate::Secp256K1Sha256>;
+
+/// Randomized parameters for a signing instance of randomized FROST.
+pub type RandomizedParams = frost_rerandomized::RandomizedParams<crate::Secp256K1Sha256>;

--- a/gencode/src/main.rs
+++ b/gencode/src/main.rs
@@ -355,6 +355,7 @@ fn main() -> ExitCode {
         for filename in [
             "README.md",
             "dkg.md",
+            "src/rerandomized.rs",
             "src/keys/dkg.rs",
             "src/keys/refresh.rs",
             "src/keys/repairable.rs",


### PR DESCRIPTION
This is something that I think will be useful, no reason to not re-export all of the generic functionality.

This also adds an `aggregate_custom()` to the `rerandomized` crate (and also re-exports it in the ciphersuite crates)