### PR TITLE
core: add ZeroizeOnDrop for dkg::round2::Package

### DIFF
--- a/frost-core/src/keys/dkg.rs
+++ b/frost-core/src/keys/dkg.rs
@@ -223,7 +223,7 @@ pub mod round2 {
     /// # Security
     ///
     /// The package must be sent on an *confidential* and *authenticated* channel.
-    #[derive(Clone, Debug, PartialEq, Eq, Getters)]
+    #[derive(Clone, Debug, PartialEq, Eq, Getters, Zeroize, ZeroizeOnDrop)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[cfg_attr(feature = "serde", serde(bound = "C: Ciphersuite"))]
     #[cfg_attr(feature = "serde", serde(deny_unknown_fields))]


### PR DESCRIPTION
Might close https://github.com/ZcashFoundation/frost/issues/1018 if we agree `round1::Package` is not needed