### PR TITLE
Add explicit release-drafter permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       # Drafts your next Release notes as Pull Requests are merged into main
       - uses: release-drafter/release-drafter@v7


### PR DESCRIPTION
This closes #1060 

Added the following block to the release-drafter CI job:
```    
permissions:
      contents: write
      pull-requests: read
```