### PR TITLE
chore: migrate to 2024 edition

### DIFF
--- a/frost-core/src/batch.rs
+++ b/frost-core/src/batch.rs
@@ -9,7 +9,7 @@
 
 use rand_core::CryptoRng;
 
-use crate::{scalar_mul::VartimeMultiscalarMul, Ciphersuite, Element, *};
+use crate::{Ciphersuite, Element, scalar_mul::VartimeMultiscalarMul, *};
 
 /// A batch verification item.
 ///

--- a/frost-core/src/benches.rs
+++ b/frost-core/src/benches.rs
@@ -9,7 +9,7 @@ use rand_core::CryptoRng;
 use criterion::{BenchmarkId, Criterion, Throughput};
 
 use crate as frost;
-use crate::{batch, Ciphersuite, Signature, SigningKey, VerifyingKey};
+use crate::{Ciphersuite, Signature, SigningKey, VerifyingKey, batch};
 
 struct Item<C: Ciphersuite> {
     vk: VerifyingKey<C>,

--- a/frost-core/src/identifier.rs
+++ b/frost-core/src/identifier.rs
@@ -8,7 +8,7 @@ use core::{
 use alloc::vec::Vec;
 
 use crate::{
-    serialization::SerializableScalar, Ciphersuite, Error, Field, FieldError, Group, Scalar,
+    Ciphersuite, Error, Field, FieldError, Group, Scalar, serialization::SerializableScalar,
 };
 
 /// A FROST participant identifier.
@@ -44,7 +44,7 @@ where
     #[cfg_attr(feature = "internals", visibility::make(pub))]
     #[cfg_attr(docsrs, doc(cfg(feature = "internals")))]
     pub(crate) fn to_scalar(&self) -> Scalar<C> {
-        self.0 .0
+        self.0.0
     }
 
     /// Derive an Identifier from an arbitrary byte string.

--- a/frost-core/src/keys.rs
+++ b/frost-core/src/keys.rs
@@ -20,9 +20,9 @@ use rand_core::CryptoRng;
 use zeroize::{DefaultIsZeroes, Zeroize, ZeroizeOnDrop};
 
 use crate::{
-    serialization::{SerializableElement, SerializableScalar},
     Ciphersuite, Element, Error, Field, Group, Header, Identifier, Scalar, SigningKey,
     VerifyingKey,
+    serialization::{SerializableElement, SerializableScalar},
 };
 
 #[cfg(feature = "serialization")]
@@ -103,7 +103,7 @@ where
     #[cfg_attr(feature = "internals", visibility::make(pub))]
     #[cfg_attr(docsrs, doc(cfg(feature = "internals")))]
     pub(crate) fn to_scalar(&self) -> Scalar<C> {
-        self.0 .0
+        self.0.0
     }
 
     /// Deserialize from bytes
@@ -182,7 +182,7 @@ where
     #[cfg_attr(docsrs, doc(cfg(feature = "internals")))]
     #[allow(dead_code)]
     pub(crate) fn to_element(&self) -> Element<C> {
-        self.0 .0
+        self.0.0
     }
 
     /// Deserialize from bytes
@@ -272,7 +272,7 @@ where
 
     /// Returns inner element value
     pub fn value(&self) -> Element<C> {
-        self.0 .0
+        self.0.0
     }
 }
 
@@ -372,7 +372,7 @@ where
     /// element in the vector), or an error if the vector is empty.
     pub(crate) fn verifying_key(&self) -> Result<VerifyingKey<C>, Error<C>> {
         Ok(VerifyingKey::new(
-            self.0.first().ok_or(Error::MissingCommitment)?.0 .0,
+            self.0.first().ok_or(Error::MissingCommitment)?.0.0,
         ))
     }
 

--- a/frost-core/src/keys/dkg.rs
+++ b/frost-core/src/keys/dkg.rs
@@ -49,9 +49,9 @@ use crate::{
 use crate::serialization::{Deserialize, Serialize};
 
 use super::{
+    KeyPackage, PublicKeyPackage, SecretShare, SigningShare, VerifiableSecretSharingCommitment,
     evaluate_polynomial, generate_coefficients, generate_secret_polynomial,
-    validate_num_of_signers, KeyPackage, PublicKeyPackage, SecretShare, SigningShare,
-    VerifiableSecretSharingCommitment,
+    validate_num_of_signers,
 };
 
 /// DKG Round 1 structures.

--- a/frost-core/src/keys/refresh.rs
+++ b/frost-core/src/keys/refresh.rs
@@ -27,18 +27,18 @@ use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 
 use crate::{
+    Ciphersuite, CryptoRng, Error, Field, Group, Header, Identifier,
     keys::dkg::{compute_proof_of_knowledge, round1, round2},
     keys::{
+        CoefficientCommitment, PublicKeyPackage, SigningKey, SigningShare, VerifyingShare,
         evaluate_polynomial, generate_coefficients, generate_secret_polynomial,
-        generate_secret_shares, validate_num_of_signers, CoefficientCommitment, PublicKeyPackage,
-        SigningKey, SigningShare, VerifyingShare,
+        generate_secret_shares, validate_num_of_signers,
     },
-    Ciphersuite, CryptoRng, Error, Field, Group, Header, Identifier,
 };
 
 use core::iter;
 
-use super::{dkg::round1::Package, KeyPackage, SecretShare, VerifiableSecretSharingCommitment};
+use super::{KeyPackage, SecretShare, VerifiableSecretSharingCommitment, dkg::round1::Package};
 
 /// Compute refreshing shares for the Trusted Dealer refresh procedure.
 ///

--- a/frost-core/src/keys/repairable.rs
+++ b/frost-core/src/keys/repairable.rs
@@ -26,10 +26,10 @@ use alloc::vec::Vec;
 use crate::keys::{KeyPackage, PublicKeyPackage};
 use crate::serialization::SerializableScalar;
 use crate::{
-    compute_lagrange_coefficient, Ciphersuite, CryptoRng, Error, Field, Group, Identifier, Scalar,
+    Ciphersuite, CryptoRng, Error, Field, Group, Identifier, Scalar, compute_lagrange_coefficient,
 };
 
-use super::{generate_coefficients, SigningShare};
+use super::{SigningShare, generate_coefficients};
 
 /// A delta value which is the output of part 1 of RTS.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -53,7 +53,7 @@ where
     #[cfg_attr(feature = "internals", visibility::make(pub))]
     #[cfg_attr(docsrs, doc(cfg(feature = "internals")))]
     pub(crate) fn to_scalar(&self) -> Scalar<C> {
-        self.0 .0
+        self.0.0
     }
 
     /// Deserialize from bytes
@@ -89,7 +89,7 @@ where
     #[cfg_attr(feature = "internals", visibility::make(pub))]
     #[cfg_attr(docsrs, doc(cfg(feature = "internals")))]
     pub(crate) fn to_scalar(&self) -> Scalar<C> {
-        self.0 .0
+        self.0.0
     }
 
     /// Deserialize from bytes

--- a/frost-core/src/round1.rs
+++ b/frost-core/src/round1.rs
@@ -17,14 +17,14 @@ use rand_core::CryptoRng;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{
-    serialization::{SerializableElement, SerializableScalar},
     Ciphersuite, Element, Error, Field, Group, Header,
+    serialization::{SerializableElement, SerializableScalar},
 };
 
 #[cfg(feature = "serialization")]
 use crate::serialization::{Deserialize, Serialize};
 
-use super::{keys::SigningShare, Identifier};
+use super::{Identifier, keys::SigningShare};
 
 /// A scalar that is a signing nonce.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -69,7 +69,7 @@ where
     pub(crate) fn to_scalar(
         self,
     ) -> <<<C as Ciphersuite>::Group as Group>::Field as Field>::Scalar {
-        self.0 .0
+        self.0.0
     }
 
     /// Generates a nonce from the given random bytes.
@@ -143,7 +143,7 @@ where
     #[cfg_attr(feature = "internals", visibility::make(pub))]
     #[cfg_attr(docsrs, doc(cfg(feature = "internals")))]
     pub(crate) fn value(&self) -> Element<C> {
-        self.0 .0
+        self.0.0
     }
 
     /// Deserialize [`NonceCommitment`] from bytes

--- a/frost-core/src/signing_key.rs
+++ b/frost-core/src/signing_key.rs
@@ -5,8 +5,8 @@ use rand_core::CryptoRng;
 use zeroize::ZeroizeOnDrop;
 
 use crate::{
-    random_nonzero, serialization::SerializableScalar, Challenge, Ciphersuite, Error, Field, Group,
-    Scalar, Signature, VerifyingKey,
+    Challenge, Ciphersuite, Error, Field, Group, Scalar, Signature, VerifyingKey, random_nonzero,
+    serialization::SerializableScalar,
 };
 
 /// A signing key for a Schnorr signature on a FROST [`Ciphersuite::Group`].

--- a/frost-core/src/tests/ciphersuite_generic.rs
+++ b/frost-core/src/tests/ciphersuite_generic.rs
@@ -11,8 +11,8 @@ use crate::keys::{SecretShare, SigningShare};
 use crate::round1::SigningNonces;
 use crate::round2::SignatureShare;
 use crate::{
-    keys::PublicKeyPackage, Error, Field, Group, Identifier, Signature, SigningKey, SigningPackage,
-    VerifyingKey,
+    Error, Field, Group, Identifier, Signature, SigningKey, SigningPackage, VerifyingKey,
+    keys::PublicKeyPackage,
 };
 
 use crate::Ciphersuite;
@@ -360,7 +360,7 @@ fn check_aggregate_corrupted_share<C: Ciphersuite + PartialEq>(
     mut signature_shares: BTreeMap<frost::Identifier<C>, frost::round2::SignatureShare<C>>,
     pubkey_package: frost::keys::PublicKeyPackage<C>,
 ) {
-    use crate::{round2::SignatureShare, CheaterDetection};
+    use crate::{CheaterDetection, round2::SignatureShare};
 
     let one = <<C as Ciphersuite>::Group as Group>::Field::one();
     // Corrupt two shares

--- a/frost-core/src/tests/coefficient_commitment.rs
+++ b/frost-core/src/tests/coefficient_commitment.rs
@@ -1,7 +1,7 @@
 //! CoefficientCommitment functions
 
 use crate as frost;
-use crate::{keys::CoefficientCommitment, tests::helpers::generate_element, Group};
+use crate::{Group, keys::CoefficientCommitment, tests::helpers::generate_element};
 use debugless_unwrap::DebuglessUnwrapExt;
 use rand_core::CryptoRng;
 use serde_json::Value;

--- a/frost-core/src/tests/refresh.rs
+++ b/frost-core/src/tests/refresh.rs
@@ -10,8 +10,8 @@ use crate::keys::refresh::{
 };
 use crate::{self as frost};
 use crate::{
-    keys::{KeyPackage, PublicKeyPackage, SecretShare},
     Ciphersuite, Error, Identifier, Signature, VerifyingKey,
+    keys::{KeyPackage, PublicKeyPackage, SecretShare},
 };
 
 use crate::tests::ciphersuite_generic::check_part3_different_participants;
@@ -596,7 +596,9 @@ pub fn check_refresh_shares_with_dkg_smaller_threshold<C: Ciphersuite + PartialE
         ));
     }
 
-    assert!(results
-        .iter()
-        .all(|r| matches!(r, Err(Error::InvalidMinSigners))));
+    assert!(
+        results
+            .iter()
+            .all(|r| matches!(r, Err(Error::InvalidMinSigners)))
+    );
 }

--- a/frost-core/src/tests/repairable.rs
+++ b/frost-core/src/tests/repairable.rs
@@ -7,15 +7,14 @@ use rand_core::CryptoRng;
 use serde_json::Value;
 
 use crate as frost;
-use crate::keys::repairable::{Delta, Sigma};
 use crate::keys::KeyPackage;
+use crate::keys::repairable::{Delta, Sigma};
 use crate::{
-    compute_lagrange_coefficient,
+    Ciphersuite, Error, Field, Group, Identifier, compute_lagrange_coefficient,
     keys::{
-        repairable::{repair_share_part1, repair_share_part2, repair_share_part3},
         PublicKeyPackage, SecretShare,
+        repairable::{repair_share_part1, repair_share_part2, repair_share_part3},
     },
-    Ciphersuite, Error, Field, Group, Identifier,
 };
 
 /// We want to test that recovered share matches the original share

--- a/frost-core/src/tests/vectors.rs
+++ b/frost-core/src/tests/vectors.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 
 use crate as frost;
 use crate::{
-    keys::*, round1::*, round2::*, Ciphersuite, Field, Group, Scalar, SigningKey, VerifyingKey, *,
+    Ciphersuite, Field, Group, Scalar, SigningKey, VerifyingKey, keys::*, round1::*, round2::*, *,
 };
 
 /// Test vectors for a ciphersuite.

--- a/frost-core/src/tests/vectors_dkg.rs
+++ b/frost-core/src/tests/vectors_dkg.rs
@@ -9,15 +9,16 @@ use hex::{self};
 use serde_json::Value;
 
 use crate::{
+    Ciphersuite, Field, Group, Header, Identifier, Scalar, Signature, SigningKey, VerifyingKey,
     keys::{
+        KeyPackage, PublicKeyPackage, SigningShare, VerifiableSecretSharingCommitment,
+        VerifyingShare,
         dkg::{
             part2, part3, round1::Package as Round1Package, round1::SecretPackage,
             round2::Package as Round2Package,
         },
-        generate_secret_polynomial, KeyPackage, PublicKeyPackage, SigningShare,
-        VerifiableSecretSharingCommitment, VerifyingShare,
+        generate_secret_polynomial,
     },
-    Ciphersuite, Field, Group, Header, Identifier, Scalar, Signature, SigningKey, VerifyingKey,
 };
 
 /// Test vectors for a ciphersuite.

--- a/frost-core/src/tests/vss_commitment.rs
+++ b/frost-core/src/tests/vss_commitment.rs
@@ -1,17 +1,17 @@
 //! VerifiableSecretSharingCommitment functions
 
 use crate::{
+    Error, Group,
     keys::{CoefficientCommitment, VerifiableSecretSharingCommitment},
     tests::helpers::generate_element,
-    Error, Group,
 };
 use alloc::vec::Vec;
 use debugless_unwrap::DebuglessUnwrapExt;
 use rand_core::CryptoRng;
 use serde_json::Value;
 
-use crate::keys::{generate_with_dealer, IdentifierList, PublicKeyPackage};
 use crate::Ciphersuite;
+use crate::keys::{IdentifierList, PublicKeyPackage, generate_with_dealer};
 
 /// Test serialize VerifiableSecretSharingCommitment
 pub fn check_serialize_vss_commitment<C: Ciphersuite, R: CryptoRng>(mut rng: R) {
@@ -41,10 +41,12 @@ pub fn check_serialize_vss_commitment<C: Ciphersuite, R: CryptoRng>(mut rng: R) 
         .unwrap();
 
     assert!(expected.len() == vss_commitment.len());
-    assert!(expected
-        .iter()
-        .zip(vss_commitment.iter())
-        .all(|(e, c)| e.as_ref() == c));
+    assert!(
+        expected
+            .iter()
+            .zip(vss_commitment.iter())
+            .all(|(e, c)| e.as_ref() == c)
+    );
 }
 
 /// Test serialize_whole VerifiableSecretSharingCommitment

--- a/frost-core/src/traits.rs
+++ b/frost-core/src/traits.rs
@@ -9,13 +9,12 @@ use alloc::{borrow::Cow, collections::BTreeMap, vec::Vec};
 use rand_core::CryptoRng;
 
 use crate::{
-    challenge,
+    BindingFactor, BindingFactorList, Challenge, Error, FieldError, GroupCommitment, GroupError,
+    Identifier, Signature, SigningKey, SigningPackage, VerifyingKey, challenge,
     keys::{KeyPackage, PublicKeyPackage, SecretShare, VerifyingShare},
     random_nonzero,
     round1::{self, SigningNonces},
     round2::{self, SignatureShare},
-    BindingFactor, BindingFactorList, Challenge, Error, FieldError, GroupCommitment, GroupError,
-    Identifier, Signature, SigningKey, SigningPackage, VerifyingKey,
 };
 
 /// A prime order finite field GF(q) over which all scalar values for our prime order group can be

--- a/frost-core/src/verifying_key.rs
+++ b/frost-core/src/verifying_key.rs
@@ -5,7 +5,7 @@ use alloc::{string::ToString, vec::Vec};
 #[cfg(any(test, feature = "test-impl"))]
 use hex::FromHex;
 
-use crate::{serialization::SerializableElement, Challenge, Ciphersuite, Error, Group, Signature};
+use crate::{Challenge, Ciphersuite, Error, Group, Signature, serialization::SerializableElement};
 
 /// A valid verifying key for Schnorr signatures over a FROST [`Ciphersuite::Group`].
 #[derive(Copy, Clone, PartialEq, Eq)]

--- a/frost-ed25519/benches/bench.rs
+++ b/frost-ed25519/benches/bench.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use frost_ed25519::*;
 

--- a/frost-ed25519/src/keys/refresh.rs
+++ b/frost-ed25519/src/keys/refresh.rs
@@ -3,9 +3,8 @@
 //! Refer to [`frost_core::keys::refresh`] for more details.
 
 use crate::{
-    frost,
+    CryptoRng, Error, Identifier, frost,
     keys::dkg::{round1, round2},
-    CryptoRng, Error, Identifier,
 };
 use alloc::{collections::btree_map::BTreeMap, vec::Vec};
 

--- a/frost-ed25519/src/keys/repairable.rs
+++ b/frost-ed25519/src/keys/repairable.rs
@@ -10,7 +10,7 @@ use crate::keys::{KeyPackage, PublicKeyPackage};
 // This is imported separately to make `gencode` work.
 // (if it were below, the position of the import would vary between ciphersuites
 //  after `cargo fmt`)
-use crate::{frost, Ciphersuite, CryptoRng, Identifier};
+use crate::{Ciphersuite, CryptoRng, Identifier, frost};
 use crate::{Ed25519Sha512, Error};
 
 /// A delta value which is the output of part 1 of RTS.

--- a/frost-ed25519/src/tests/proptests.rs
+++ b/frost-ed25519/src/tests/proptests.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use frost_core::tests::proptests::{tweak_strategy, SignatureCase};
+use frost_core::tests::proptests::{SignatureCase, tweak_strategy};
 use proptest::prelude::*;
 
 use rand_chacha::ChaChaRng;

--- a/frost-ed25519/tests/helpers/samples.rs
+++ b/frost-ed25519/tests/helpers/samples.rs
@@ -2,16 +2,16 @@
 
 use std::collections::BTreeMap;
 
-use frost_core::{round1::Nonce, Ciphersuite, Element, Group, Scalar};
+use frost_core::{Ciphersuite, Element, Group, Scalar, round1::Nonce};
 use frost_ed25519::{
+    Field, Signature, SigningPackage, VerifyingKey,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare, SigningShare, VerifiableSecretSharingCommitment,
         VerifyingShare,
+        dkg::{round1, round2},
     },
     round1::{NonceCommitment, SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    Field, Signature, SigningPackage, VerifyingKey,
 };
 
 type C = frost_ed25519::Ed25519Sha512;

--- a/frost-ed25519/tests/recreation_tests.rs
+++ b/frost-ed25519/tests/recreation_tests.rs
@@ -2,13 +2,13 @@
 //! can be serialized and deserialized as the user wishes.
 
 use frost_ed25519::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::{SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    SigningPackage,
 };
 
 mod helpers;

--- a/frost-ed25519/tests/serde_tests.rs
+++ b/frost-ed25519/tests/serde_tests.rs
@@ -3,13 +3,13 @@
 mod helpers;
 
 use frost_ed25519::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::SigningCommitments,
     round2::SignatureShare,
-    SigningPackage,
 };
 
 use helpers::samples;

--- a/frost-ed25519/tests/serialization_tests.rs
+++ b/frost-ed25519/tests/serialization_tests.rs
@@ -3,13 +3,13 @@
 mod helpers;
 
 use frost_ed25519::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::{SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    SigningPackage,
 };
 
 use helpers::samples;

--- a/frost-ed448/benches/bench.rs
+++ b/frost-ed448/benches/bench.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use frost_ed448::*;
 

--- a/frost-ed448/src/keys/refresh.rs
+++ b/frost-ed448/src/keys/refresh.rs
@@ -3,9 +3,8 @@
 //! Refer to [`frost_core::keys::refresh`] for more details.
 
 use crate::{
-    frost,
+    CryptoRng, Error, Identifier, frost,
     keys::dkg::{round1, round2},
-    CryptoRng, Error, Identifier,
 };
 use alloc::{collections::btree_map::BTreeMap, vec::Vec};
 

--- a/frost-ed448/src/keys/repairable.rs
+++ b/frost-ed448/src/keys/repairable.rs
@@ -10,7 +10,7 @@ use crate::keys::{KeyPackage, PublicKeyPackage};
 // This is imported separately to make `gencode` work.
 // (if it were below, the position of the import would vary between ciphersuites
 //  after `cargo fmt`)
-use crate::{frost, Ciphersuite, CryptoRng, Identifier};
+use crate::{Ciphersuite, CryptoRng, Identifier, frost};
 use crate::{Ed448Shake256, Error};
 
 /// A delta value which is the output of part 1 of RTS.

--- a/frost-ed448/src/tests/proptests.rs
+++ b/frost-ed448/src/tests/proptests.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use frost_core::tests::proptests::{tweak_strategy, SignatureCase};
+use frost_core::tests::proptests::{SignatureCase, tweak_strategy};
 use proptest::prelude::*;
 
 use rand_chacha::ChaChaRng;

--- a/frost-ed448/tests/helpers/samples.rs
+++ b/frost-ed448/tests/helpers/samples.rs
@@ -2,16 +2,16 @@
 
 use std::collections::BTreeMap;
 
-use frost_core::{round1::Nonce, Ciphersuite, Element, Group, Scalar};
+use frost_core::{Ciphersuite, Element, Group, Scalar, round1::Nonce};
 use frost_ed448::{
+    Field, Signature, SigningPackage, VerifyingKey,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare, SigningShare, VerifiableSecretSharingCommitment,
         VerifyingShare,
+        dkg::{round1, round2},
     },
     round1::{NonceCommitment, SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    Field, Signature, SigningPackage, VerifyingKey,
 };
 
 type C = frost_ed448::Ed448Shake256;

--- a/frost-ed448/tests/recreation_tests.rs
+++ b/frost-ed448/tests/recreation_tests.rs
@@ -2,13 +2,13 @@
 //! can be serialized and deserialized as the user wishes.
 
 use frost_ed448::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::{SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    SigningPackage,
 };
 
 mod helpers;

--- a/frost-ed448/tests/serde_tests.rs
+++ b/frost-ed448/tests/serde_tests.rs
@@ -3,13 +3,13 @@
 mod helpers;
 
 use frost_ed448::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::SigningCommitments,
     round2::SignatureShare,
-    SigningPackage,
 };
 
 use helpers::samples;

--- a/frost-ed448/tests/serialization_tests.rs
+++ b/frost-ed448/tests/serialization_tests.rs
@@ -3,13 +3,13 @@
 mod helpers;
 
 use frost_ed448::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::{SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    SigningPackage,
 };
 
 use helpers::samples;

--- a/frost-p256/benches/bench.rs
+++ b/frost-p256/benches/bench.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use frost_p256::*;
 

--- a/frost-p256/src/keys/refresh.rs
+++ b/frost-p256/src/keys/refresh.rs
@@ -3,9 +3,8 @@
 //! Refer to [`frost_core::keys::refresh`] for more details.
 
 use crate::{
-    frost,
+    CryptoRng, Error, Identifier, frost,
     keys::dkg::{round1, round2},
-    CryptoRng, Error, Identifier,
 };
 use alloc::{collections::btree_map::BTreeMap, vec::Vec};
 

--- a/frost-p256/src/keys/repairable.rs
+++ b/frost-p256/src/keys/repairable.rs
@@ -10,7 +10,7 @@ use crate::keys::{KeyPackage, PublicKeyPackage};
 // This is imported separately to make `gencode` work.
 // (if it were below, the position of the import would vary between ciphersuites
 //  after `cargo fmt`)
-use crate::{frost, Ciphersuite, CryptoRng, Identifier};
+use crate::{Ciphersuite, CryptoRng, Identifier, frost};
 use crate::{Error, P256Sha256};
 
 /// A delta value which is the output of part 1 of RTS.

--- a/frost-p256/src/lib.rs
+++ b/frost-p256/src/lib.rs
@@ -14,12 +14,12 @@ use alloc::collections::BTreeMap;
 
 use frost_rerandomized::RandomizedCiphersuite;
 use p256::{
-    elliptic_curve::{
-        sec1::{FromSec1Point, ToSec1Point},
-        Field as FFField, PrimeField,
-    },
-    hash2curve::{hash_to_field, ExpandMsgXmd, MapToCurve},
     AffinePoint, NistP256, ProjectivePoint, Scalar,
+    elliptic_curve::{
+        Field as FFField, PrimeField,
+        sec1::{FromSec1Point, ToSec1Point},
+    },
+    hash2curve::{ExpandMsgXmd, MapToCurve, hash_to_field},
 };
 use rand_core::CryptoRng;
 use sha2::{Digest, Sha256};

--- a/frost-p256/src/tests/proptests.rs
+++ b/frost-p256/src/tests/proptests.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use frost_core::tests::proptests::{tweak_strategy, SignatureCase};
+use frost_core::tests::proptests::{SignatureCase, tweak_strategy};
 use proptest::prelude::*;
 
 use rand_chacha::ChaChaRng;

--- a/frost-p256/tests/helpers/samples.rs
+++ b/frost-p256/tests/helpers/samples.rs
@@ -2,16 +2,16 @@
 
 use std::collections::BTreeMap;
 
-use frost_core::{round1::Nonce, Ciphersuite, Element, Group, Scalar};
+use frost_core::{Ciphersuite, Element, Group, Scalar, round1::Nonce};
 use frost_p256::{
+    Field, Signature, SigningPackage, VerifyingKey,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare, SigningShare, VerifiableSecretSharingCommitment,
         VerifyingShare,
+        dkg::{round1, round2},
     },
     round1::{NonceCommitment, SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    Field, Signature, SigningPackage, VerifyingKey,
 };
 
 type C = frost_p256::P256Sha256;

--- a/frost-p256/tests/recreation_tests.rs
+++ b/frost-p256/tests/recreation_tests.rs
@@ -2,13 +2,13 @@
 //! can be serialized and deserialized as the user wishes.
 
 use frost_p256::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::{SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    SigningPackage,
 };
 
 mod helpers;

--- a/frost-p256/tests/serde_tests.rs
+++ b/frost-p256/tests/serde_tests.rs
@@ -3,13 +3,13 @@
 mod helpers;
 
 use frost_p256::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::SigningCommitments,
     round2::SignatureShare,
-    SigningPackage,
 };
 
 use helpers::samples;

--- a/frost-p256/tests/serialization_tests.rs
+++ b/frost-p256/tests/serialization_tests.rs
@@ -3,13 +3,13 @@
 mod helpers;
 
 use frost_p256::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::{SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    SigningPackage,
 };
 
 use helpers::samples;

--- a/frost-rerandomized/src/lib.rs
+++ b/frost-rerandomized/src/lib.rs
@@ -28,11 +28,11 @@ pub use frost_core;
 #[cfg(feature = "serialization")]
 use frost_core::SigningPackage;
 use frost_core::{
-    self as frost,
+    self as frost, CheaterDetection, Ciphersuite, Error, Field, Group, Identifier, Scalar,
+    VerifyingKey,
     keys::{KeyPackage, PublicKeyPackage, SigningShare, VerifyingShare},
-    round1::{encode_group_commitments, SigningCommitments},
+    round1::{SigningCommitments, encode_group_commitments},
     serialization::SerializableScalar,
-    CheaterDetection, Ciphersuite, Error, Field, Group, Identifier, Scalar, VerifyingKey,
 };
 
 #[cfg(feature = "serde")]
@@ -217,7 +217,7 @@ where
     C: Ciphersuite,
 {
     pub(crate) fn to_scalar(self) -> Scalar<C> {
-        self.0 .0
+        self.0.0
     }
 }
 

--- a/frost-rerandomized/src/tests.rs
+++ b/frost-rerandomized/src/tests.rs
@@ -5,9 +5,9 @@ use alloc::borrow::ToOwned;
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 
-use crate::{frost_core as frost, RandomizedCiphersuite, RandomizedParams, Randomizer};
+use crate::{RandomizedCiphersuite, RandomizedParams, Randomizer, frost_core as frost};
 use frost_core::{
-    round1::SigningCommitments, Field, Group, Identifier, Signature, SigningPackage, VerifyingKey,
+    Field, Group, Identifier, Signature, SigningPackage, VerifyingKey, round1::SigningCommitments,
 };
 use rand_core::CryptoRng;
 
@@ -118,10 +118,12 @@ pub fn check_randomized_sign_with_dealer<C: RandomizedCiphersuite, R: CryptoRng>
 
     // Check that the threshold signature can be verified by the randomized group public
     // key (the verification key).
-    assert!(randomizer_params
-        .randomized_verifying_key()
-        .verify(message, &group_signature)
-        .is_ok());
+    assert!(
+        randomizer_params
+            .randomized_verifying_key()
+            .verify(message, &group_signature)
+            .is_ok()
+    );
 
     // Note that key_package.verifying_key can't be used to verify the signature
     // since those are non-randomized.

--- a/frost-ristretto255/benches/bench.rs
+++ b/frost-ristretto255/benches/bench.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use frost_ristretto255::*;
 

--- a/frost-ristretto255/src/keys/refresh.rs
+++ b/frost-ristretto255/src/keys/refresh.rs
@@ -3,9 +3,8 @@
 //! Refer to [`frost_core::keys::refresh`] for more details.
 
 use crate::{
-    frost,
+    CryptoRng, Error, Identifier, frost,
     keys::dkg::{round1, round2},
-    CryptoRng, Error, Identifier,
 };
 use alloc::{collections::btree_map::BTreeMap, vec::Vec};
 

--- a/frost-ristretto255/src/keys/repairable.rs
+++ b/frost-ristretto255/src/keys/repairable.rs
@@ -10,7 +10,7 @@ use crate::keys::{KeyPackage, PublicKeyPackage};
 // This is imported separately to make `gencode` work.
 // (if it were below, the position of the import would vary between ciphersuites
 //  after `cargo fmt`)
-use crate::{frost, Ciphersuite, CryptoRng, Identifier};
+use crate::{Ciphersuite, CryptoRng, Identifier, frost};
 use crate::{Error, Ristretto255Sha512};
 
 /// A delta value which is the output of part 1 of RTS.

--- a/frost-ristretto255/src/tests/proptests.rs
+++ b/frost-ristretto255/src/tests/proptests.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use frost_core::tests::proptests::{tweak_strategy, SignatureCase};
+use frost_core::tests::proptests::{SignatureCase, tweak_strategy};
 use proptest::prelude::*;
 
 use rand_chacha::ChaChaRng;

--- a/frost-ristretto255/tests/helpers/samples.rs
+++ b/frost-ristretto255/tests/helpers/samples.rs
@@ -2,16 +2,16 @@
 
 use std::collections::BTreeMap;
 
-use frost_core::{round1::Nonce, Ciphersuite, Element, Group, Scalar};
+use frost_core::{Ciphersuite, Element, Group, Scalar, round1::Nonce};
 use frost_ristretto255::{
+    Field, Signature, SigningPackage, VerifyingKey,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare, SigningShare, VerifiableSecretSharingCommitment,
         VerifyingShare,
+        dkg::{round1, round2},
     },
     round1::{NonceCommitment, SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    Field, Signature, SigningPackage, VerifyingKey,
 };
 
 type C = frost_ristretto255::Ristretto255Sha512;

--- a/frost-ristretto255/tests/recreation_tests.rs
+++ b/frost-ristretto255/tests/recreation_tests.rs
@@ -2,13 +2,13 @@
 //! can be serialized and deserialized as the user wishes.
 
 use frost_ristretto255::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::{SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    SigningPackage,
 };
 
 mod helpers;

--- a/frost-ristretto255/tests/serde_tests.rs
+++ b/frost-ristretto255/tests/serde_tests.rs
@@ -3,13 +3,13 @@
 mod helpers;
 
 use frost_ristretto255::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::SigningCommitments,
     round2::SignatureShare,
-    SigningPackage,
 };
 
 use helpers::samples;

--- a/frost-ristretto255/tests/serialization_tests.rs
+++ b/frost-ristretto255/tests/serialization_tests.rs
@@ -3,13 +3,13 @@
 mod helpers;
 
 use frost_ristretto255::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::{SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    SigningPackage,
 };
 
 use helpers::samples;

--- a/frost-secp256k1-tr/benches/bench.rs
+++ b/frost-secp256k1-tr/benches/bench.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use frost_secp256k1_tr::*;
 

--- a/frost-secp256k1-tr/src/keys/refresh.rs
+++ b/frost-secp256k1-tr/src/keys/refresh.rs
@@ -3,9 +3,8 @@
 //! Refer to [`frost_core::keys::refresh`] for more details.
 
 use crate::{
-    frost,
+    CryptoRng, Error, Identifier, frost,
     keys::dkg::{round1, round2},
-    CryptoRng, Error, Identifier,
 };
 use alloc::{collections::btree_map::BTreeMap, vec::Vec};
 

--- a/frost-secp256k1-tr/src/keys/repairable.rs
+++ b/frost-secp256k1-tr/src/keys/repairable.rs
@@ -10,7 +10,7 @@ use crate::keys::{KeyPackage, PublicKeyPackage};
 // This is imported separately to make `gencode` work.
 // (if it were below, the position of the import would vary between ciphersuites
 //  after `cargo fmt`)
-use crate::{frost, Ciphersuite, CryptoRng, Identifier};
+use crate::{Ciphersuite, CryptoRng, Identifier, frost};
 use crate::{Error, Secp256K1Sha256TR};
 
 /// A delta value which is the output of part 1 of RTS.

--- a/frost-secp256k1-tr/src/lib.rs
+++ b/frost-secp256k1-tr/src/lib.rs
@@ -15,14 +15,14 @@ use alloc::{borrow::Cow, collections::BTreeMap, vec::Vec};
 
 use frost_rerandomized::RandomizedCiphersuite;
 use k256::{
+    AffinePoint, ProjectivePoint, Scalar, Secp256k1, U256,
     elliptic_curve::{
+        CurveAffine, Field as FFField, PrimeField,
         ops::Reduce,
         point::AffineCoordinates,
         sec1::{FromSec1Point, ToSec1Point},
-        CurveAffine, Field as FFField, PrimeField,
     },
-    hash2curve::{hash_to_field, ExpandMsgXmd, MapToCurve},
-    AffinePoint, ProjectivePoint, Scalar, Secp256k1, U256,
+    hash2curve::{ExpandMsgXmd, MapToCurve, hash_to_field},
 };
 use rand_core::CryptoRng;
 use sha2::{Digest, Sha256};

--- a/frost-secp256k1-tr/src/tests/proptests.rs
+++ b/frost-secp256k1-tr/src/tests/proptests.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use frost_core::tests::proptests::{tweak_strategy, SignatureCase};
+use frost_core::tests::proptests::{SignatureCase, tweak_strategy};
 use proptest::prelude::*;
 
 use rand_chacha::ChaChaRng;

--- a/frost-secp256k1-tr/tests/helpers/samples.rs
+++ b/frost-secp256k1-tr/tests/helpers/samples.rs
@@ -2,16 +2,16 @@
 
 use std::collections::BTreeMap;
 
-use frost_core::{round1::Nonce, Ciphersuite, Element, Group, Scalar};
+use frost_core::{Ciphersuite, Element, Group, Scalar, round1::Nonce};
 use frost_secp256k1_tr::{
+    Field, Signature, SigningPackage, VerifyingKey,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare, SigningShare, VerifiableSecretSharingCommitment,
         VerifyingShare,
+        dkg::{round1, round2},
     },
     round1::{NonceCommitment, SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    Field, Signature, SigningPackage, VerifyingKey,
 };
 
 type C = frost_secp256k1_tr::Secp256K1Sha256TR;

--- a/frost-secp256k1-tr/tests/recreation_tests.rs
+++ b/frost-secp256k1-tr/tests/recreation_tests.rs
@@ -2,13 +2,13 @@
 //! can be serialized and deserialized as the user wishes.
 
 use frost_secp256k1_tr::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::{SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    SigningPackage,
 };
 
 mod helpers;

--- a/frost-secp256k1-tr/tests/serde_tests.rs
+++ b/frost-secp256k1-tr/tests/serde_tests.rs
@@ -3,13 +3,13 @@
 mod helpers;
 
 use frost_secp256k1_tr::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::SigningCommitments,
     round2::SignatureShare,
-    SigningPackage,
 };
 
 use helpers::samples;

--- a/frost-secp256k1-tr/tests/serialization_tests.rs
+++ b/frost-secp256k1-tr/tests/serialization_tests.rs
@@ -3,13 +3,13 @@
 mod helpers;
 
 use frost_secp256k1_tr::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::{SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    SigningPackage,
 };
 
 use helpers::samples;

--- a/frost-secp256k1-tr/tests/tweaking_tests.rs
+++ b/frost-secp256k1-tr/tests/tweaking_tests.rs
@@ -1,7 +1,7 @@
 use std::{error::Error, vec};
 
-use k256::elliptic_curve::point::AffineCoordinates;
 use k256::ProjectivePoint;
+use k256::elliptic_curve::point::AffineCoordinates;
 use keys::Tweak;
 use sha2::{Digest, Sha256};
 

--- a/frost-secp256k1/benches/bench.rs
+++ b/frost-secp256k1/benches/bench.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use frost_secp256k1::*;
 

--- a/frost-secp256k1/src/keys/refresh.rs
+++ b/frost-secp256k1/src/keys/refresh.rs
@@ -3,9 +3,8 @@
 //! Refer to [`frost_core::keys::refresh`] for more details.
 
 use crate::{
-    frost,
+    CryptoRng, Error, Identifier, frost,
     keys::dkg::{round1, round2},
-    CryptoRng, Error, Identifier,
 };
 use alloc::{collections::btree_map::BTreeMap, vec::Vec};
 

--- a/frost-secp256k1/src/keys/repairable.rs
+++ b/frost-secp256k1/src/keys/repairable.rs
@@ -10,7 +10,7 @@ use crate::keys::{KeyPackage, PublicKeyPackage};
 // This is imported separately to make `gencode` work.
 // (if it were below, the position of the import would vary between ciphersuites
 //  after `cargo fmt`)
-use crate::{frost, Ciphersuite, CryptoRng, Identifier};
+use crate::{Ciphersuite, CryptoRng, Identifier, frost};
 use crate::{Error, Secp256K1Sha256};
 
 /// A delta value which is the output of part 1 of RTS.

--- a/frost-secp256k1/src/lib.rs
+++ b/frost-secp256k1/src/lib.rs
@@ -14,12 +14,12 @@ use alloc::collections::BTreeMap;
 
 use frost_rerandomized::RandomizedCiphersuite;
 use k256::{
-    elliptic_curve::{
-        sec1::{FromSec1Point, ToSec1Point},
-        CurveAffine, Field as FFField, PrimeField,
-    },
-    hash2curve::{hash_to_field, ExpandMsgXmd, MapToCurve},
     AffinePoint, ProjectivePoint, Scalar, Secp256k1,
+    elliptic_curve::{
+        CurveAffine, Field as FFField, PrimeField,
+        sec1::{FromSec1Point, ToSec1Point},
+    },
+    hash2curve::{ExpandMsgXmd, MapToCurve, hash_to_field},
 };
 use rand_core::CryptoRng;
 use sha2::{Digest, Sha256};

--- a/frost-secp256k1/src/tests/proptests.rs
+++ b/frost-secp256k1/src/tests/proptests.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use frost_core::tests::proptests::{tweak_strategy, SignatureCase};
+use frost_core::tests::proptests::{SignatureCase, tweak_strategy};
 use proptest::prelude::*;
 
 use rand_chacha::ChaChaRng;

--- a/frost-secp256k1/tests/helpers/samples.rs
+++ b/frost-secp256k1/tests/helpers/samples.rs
@@ -2,16 +2,16 @@
 
 use std::collections::BTreeMap;
 
-use frost_core::{round1::Nonce, Ciphersuite, Element, Group, Scalar};
+use frost_core::{Ciphersuite, Element, Group, Scalar, round1::Nonce};
 use frost_secp256k1::{
+    Field, Signature, SigningPackage, VerifyingKey,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare, SigningShare, VerifiableSecretSharingCommitment,
         VerifyingShare,
+        dkg::{round1, round2},
     },
     round1::{NonceCommitment, SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    Field, Signature, SigningPackage, VerifyingKey,
 };
 
 type C = frost_secp256k1::Secp256K1Sha256;

--- a/frost-secp256k1/tests/recreation_tests.rs
+++ b/frost-secp256k1/tests/recreation_tests.rs
@@ -2,13 +2,13 @@
 //! can be serialized and deserialized as the user wishes.
 
 use frost_secp256k1::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::{SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    SigningPackage,
 };
 
 mod helpers;

--- a/frost-secp256k1/tests/serde_tests.rs
+++ b/frost-secp256k1/tests/serde_tests.rs
@@ -3,13 +3,13 @@
 mod helpers;
 
 use frost_secp256k1::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::SigningCommitments,
     round2::SignatureShare,
-    SigningPackage,
 };
 
 use helpers::samples;

--- a/frost-secp256k1/tests/serialization_tests.rs
+++ b/frost-secp256k1/tests/serialization_tests.rs
@@ -3,13 +3,13 @@
 mod helpers;
 
 use frost_secp256k1::{
+    SigningPackage,
     keys::{
-        dkg::{round1, round2},
         KeyPackage, PublicKeyPackage, SecretShare,
+        dkg::{round1, round2},
     },
     round1::{SigningCommitments, SigningNonces},
     round2::SignatureShare,
-    SigningPackage,
 };
 
 use helpers::samples;

--- a/gencode/src/main.rs
+++ b/gencode/src/main.rs
@@ -167,7 +167,7 @@ fn copy_and_replace(
 pub fn rustfmt(source: String) -> String {
     let mut child = Command::new("rustfmt")
         .arg("--edition")
-        .arg("2021") // TODO: remove this file once PR in merged (this is used to reduce diff)
+        .arg("2024")
         .stdin(Stdio::piped())
         .stderr(Stdio::piped())
         .stdout(Stdio::piped())

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-# TODO: remove this file once PR in merged (this is used to reduce diff)
-style_edition = "2021"


### PR DESCRIPTION
In #903 the edition was held back to minimize the diff; this migrates to 2024 and removes the TODOs added there